### PR TITLE
Set codecov CI requirement to be raw threshold

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,6 @@
 coverage:
   status:
+    patch: off
     project:
       default:
         threshold: 1%  # Allow 1% tolerance

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%  # Allow 1% tolerance
+        target: 70%    # The minimum coverage required


### PR DESCRIPTION
### Changes

Changes Codecov CI passing from nonnegative delta to requirement to >= 70% code coverage.

For reviewers: Refer to the Notes section below. Prior to this PR, the Codecov entry is `codecov/patch`, now it is `codecov/project`

### Remarks

The Codecov CI passing requirement is, by default, that the percentage of code covered by tests should not decrease, if a PR is merged. This is quite strict, especially if introducing code that might not exactly need tests.

As linked in #65, [the CS2103T website](https://github.com/nus-cs2103-AY2425S1/forum/issues/474) says that we can skip (default) CI checks in cases where the Codecov CI failing is not meaningful.

Another idea proposed is to set a (reasonable) minimum raw threshold for code coverage. If it goes below 70%, then perhaps we can review this value again. Once we have added most of the code that may not need testing, such as GUI or enums, we can also review again whether to go back to the default CI requirement

### Notes

Before this PR:

![image](https://github.com/user-attachments/assets/07d9e6b4-a11d-463e-8ea3-ee2ec0021291)

After making config changes:

![image](https://github.com/user-attachments/assets/ee4fdd07-7f9e-43d1-8ff8-208c5dadd74e)

After duplicating `RoleType.java` to purposely force a decrease in code coverage to test that it works:

![image](https://github.com/user-attachments/assets/7286f0ac-8260-4202-8a2e-04d8d18cd6c1)