### PR TITLE
Bugfix: find command crashes

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,6 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_EMPTY_FIND_KEYWORD = "Find keyword(s) cannot be empty!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person(s) found with keyword(s): %2$s";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,6 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_EMPTY_FIND_KEYWORD = "Find keyword(s) cannot be empty!";
+    public static final String MESSAGE_FIND_KEYWORD_CONTAINS_WHITESPACE = "Find keyword(s) cannot contain whitespace(s)!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person(s) found with keyword(s): %2$s";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_EMPTY_FIND_KEYWORD = "Find keyword(s) cannot be empty!";
-    public static final String MESSAGE_FIND_KEYWORD_CONTAINS_WHITESPACE = "Find keyword(s) cannot contain whitespace(s)!";
+    public static final String MESSAGE_FIND_KEYWORD_CONTAINS_WHITESPACE =
+            "Find keyword(s) cannot contain whitespace(s)!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person(s) found with keyword(s): %2$s";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIND_KEYWORD;
+import static seedu.address.logic.Messages.MESSAGE_FIND_KEYWORD_CONTAINS_WHITESPACE;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
@@ -32,8 +33,12 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
 
+        // all keywords must be non-empty and contain no whitespace
         if (nameKeywords.stream().anyMatch(String::isBlank)) {
             throw new ParseException(MESSAGE_EMPTY_FIND_KEYWORD);
+        }
+        if (nameKeywords.stream().anyMatch(s -> s.contains(" "))) {
+            throw new ParseException(MESSAGE_FIND_KEYWORD_CONTAINS_WHITESPACE);
         }
 
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords));

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIND_KEYWORD;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
@@ -30,6 +31,10 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+
+        if (nameKeywords.stream().anyMatch(String::isBlank)) {
+            throw new ParseException(MESSAGE_EMPTY_FIND_KEYWORD);
+        }
 
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords));
     }


### PR DESCRIPTION
I have noted two cases when the updated `find` command crashes:
- Any of the keyword(s) is empty, e.g. `find n/`
- Any of the keyword(s) contains whitespace(s), e.g. `find n/Alex Goh`

For a temporary fix, I have rejected both types of inputs with appropriate error messages. However, the second case may be desired, but requires some deeper investigation into why javafx's FilteredList does not accept multiple-word keywords.