### PR TITLE
Allow find command to accept keywords with spaces

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -39,6 +39,28 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains the {@code substring}.
+     *   Ignores case, but returns true iff {@code substring} is a continuous substring of {@code sentence}.
+     *   <br>examples:<pre>
+     *       containsWordIgnoreCase("ABc def", "abc") == true
+     *       containsWordIgnoreCase("ABc def", "abc DEF") == true
+     *       containsWordIgnoreCase("ABc def", "DEF") == true
+     *       containsWordIgnoreCase("ABc def", "ABC DE") == true
+     *       </pre>
+     * @param sentence cannot be null
+     * @param substring cannot be null, cannot be empty
+     */
+    public static boolean containsSubstringIgnoreCase(String sentence, String substring) {
+        requireNonNull(sentence);
+        requireNonNull(substring);
+
+        String preppedSubstring = substring.trim();
+        checkArgument(!preppedSubstring.isEmpty(), "Substring parameter cannot be empty");
+
+        return sentence.toLowerCase().contains(preppedSubstring.toLowerCase());
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.stream.Collectors;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
@@ -40,7 +42,10 @@ public class FindCommand extends Command {
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
                         model.getFilteredPersonList().size(),
-                        String.join(" ", predicate.getKeywords()))
+                        predicate.getKeywords().stream()
+                                .map(kw -> "\"" + kw + "\"")
+                                .collect(Collectors.joining(", "))
+                )
         );
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIND_KEYWORD;
-import static seedu.address.logic.Messages.MESSAGE_FIND_KEYWORD_CONTAINS_WHITESPACE;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -37,9 +37,6 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (nameKeywords.stream().anyMatch(String::isBlank)) {
             throw new ParseException(MESSAGE_EMPTY_FIND_KEYWORD);
         }
-        if (nameKeywords.stream().anyMatch(s -> s.contains(" "))) {
-            throw new ParseException(MESSAGE_FIND_KEYWORD_CONTAINS_WHITESPACE);
-        }
 
         return new FindCommand(new NameContainsKeywordsPredicate(nameKeywords));
     }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsSubstringIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -57,7 +57,9 @@ public class StringUtilTest {
 
     @Test
     public void containsSubstringIgnoreCase_nullSubstring_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsSubstringIgnoreCase("typical sentence", null));
+        assertThrows(
+                NullPointerException.class, () -> StringUtil.containsSubstringIgnoreCase("typical sentence", null)
+        );
     }
 
     @Test

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -46,6 +46,110 @@ public class StringUtilTest {
     }
 
 
+
+    //---------------- Tests for containsSubstringIgnoreCase ---------------------------------
+
+    /*
+     * Invalid equivalence partitions for substring: null, empty
+     * Invalid equivalence partitions for sentence: null
+     * The three test cases below test one invalid input at a time.
+     */
+
+    @Test
+    public void containsSubstringIgnoreCase_nullSubstring_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsSubstringIgnoreCase("typical sentence", null));
+    }
+
+    @Test
+    public void containsSubstringIgnoreCase_emptySubstring_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Substring parameter cannot be empty", ()
+                -> StringUtil.containsSubstringIgnoreCase("typical sentence", "  "));
+    }
+
+    @Test
+    public void containsSubstringIgnoreCase_nullSentence_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsSubstringIgnoreCase(null, "abc"));
+    }
+
+    /*
+     * Valid equivalence partitions for substring:
+     *   - one word
+     *   - multiple words
+     *   - string containing symbols/numbers
+     *   - string with leading/trailing spaces
+     *
+     * Valid equivalence partitions for sentence:
+     *   - empty string
+     *   - one word
+     *   - multiple words
+     *   - sentence with extra spaces
+     *
+     * Possible scenarios returning true:
+     *   - matches prefix of sentence
+     *   - matches suffix of sentence
+     *   - matches middle word in sentence
+     *   - matches multiple substrings
+     *
+     * Possible scenarios returning false:
+     *   - query substring exists but is discontinuous
+     *   - sentence matches part of the query substring
+     *
+     * The test method below tries to verify all above with a reasonably low number of test cases.
+     */
+
+    @Test
+    public void containsSubstringIgnoreCase_validInputs_correctResult() {
+
+        // Empty sentence
+        assertFalse(StringUtil.containsSubstringIgnoreCase("", "ab c"));
+        assertFalse(StringUtil.containsSubstringIgnoreCase("    ", "123"));
+
+        // Query substring exists but is discontinuous
+        assertFalse(
+                StringUtil.containsSubstringIgnoreCase("abc def ghi", "ac")
+        ); // Query substring partitioned by a letter
+        assertFalse(
+                StringUtil.containsSubstringIgnoreCase("abc def ghi", "abcdef")
+        ); // Query substring partitioned by a space
+        assertFalse(
+                StringUtil.containsSubstringIgnoreCase("abc def ghi", "abc ghi")
+        ); // Query substring partitioned by a word
+
+        // Sentence matches part of the query substring only
+        assertFalse(
+                StringUtil.containsSubstringIgnoreCase("abc def ghi", "abc defg")
+        ); // Prefix of query substring is matched
+        assertFalse(
+                StringUtil.containsSubstringIgnoreCase("PetER ChoO", "  METer")
+        ); // Suffix of query substring is matched
+        assertFalse(
+                StringUtil.containsSubstringIgnoreCase("abc def ghi", "z def z")
+        ); // Middle part of query substring is matched
+        assertFalse(
+                StringUtil.containsSubstringIgnoreCase("abc  def ghi", "abc    def")
+        ); // Query substring contains more spaces in between
+
+        // Matches Substring in the sentence, different upper/lower case letters
+        assertTrue(
+                StringUtil.containsSubstringIgnoreCase("aaa bBb ccc", "AaA BB")
+        ); // Prefix (boundary case)
+        assertTrue(
+                StringUtil.containsSubstringIgnoreCase("aaa bBb ccc@1", "BB CCc@1")
+        ); // Suffix (boundary case)
+        assertTrue(
+                StringUtil.containsSubstringIgnoreCase("  AAA   bBb   ccc  ", " aaa   bbb     ")
+        ); // Sentence has extra spaces
+        assertTrue(
+                StringUtil.containsSubstringIgnoreCase("Aaa", "aA")
+        ); // Only one word in sentence (boundary case)
+        assertTrue(
+                StringUtil.containsSubstringIgnoreCase("aaa bbb ccc", "  a b  ")
+        ); // Leading/trailing spaces
+
+        // Matches multiple Substrings in sentence
+        assertTrue(StringUtil.containsSubstringIgnoreCase("AAA AAA aAa", "aa A"));
+    }
+
     //---------------- Tests for containsWordIgnoreCase --------------------------------------
 
     /*

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -66,7 +66,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3, "Kurz Elle Kunz");
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3, "\"Kurz\", \"Elle\", \"Kunz\"");
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);


### PR DESCRIPTION
Modify `find` behavior such that
- query string can contain whitespaces, e.g. `find n/Alex Yeoh`
- a name matches a query string iff the query string exists continuously within the name, case ignored
- If multiple query strings are provided, they are tests with an `or` relationship - all entries matching at least one query string are included in the resulting list

For better clarity, you can refer to the testcases I wrote for `StringUtil.containsSubstringIgnoreCase()`.

`StringUtil.containsSubstringIgnoreCase()` is a new method I wrote in place of the old `StringUtil.containsWordIgnoreCase()` to suit our needs. The latter requires a 'full word match' (i.e. 'partial' will not match 'impartial judgement'), but since our query string can be a phrase now, such requirement is no longer valid in our context.

That said, I kept `StringUtil.containsWordIgnoreCase()` in case we need it later. If we don't, we can delete it at a later iteration.

closes #85 
This PR could also close #80 since we have removed the full word match constraint. Can someone help double check with this?