### PR TITLE
Add module role map attribute in person

### DIFF
--- a/src/main/java/seedu/address/model/person/ModuleRoleMap.java
+++ b/src/main/java/seedu/address/model/person/ModuleRoleMap.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.management.relation.Role;
-
 /**
  * Represents the mapping between module and role type in the roles
  * taken by a Person in NUS.

--- a/src/main/java/seedu/address/model/person/ModuleRoleMap.java
+++ b/src/main/java/seedu/address/model/person/ModuleRoleMap.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.management.relation.Role;
+
 /**
  * Represents the mapping between module and role type in the roles
  * taken by a Person in NUS.
@@ -155,5 +157,13 @@ public class ModuleRoleMap {
     @Override
     public int hashCode() {
         return this.roles.hashCode();
+    }
+
+    /**
+     * Gets the roles in HashMap.
+     *
+     */
+    public HashMap<ModuleCode, RoleType> getRoles() {
+        return this.roles;
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,18 +26,7 @@ public class Person {
     // Data fields
     private final Optional<Address> address;
     private final Set<Tag> tags = new HashSet<>();
-
-    /**
-     * Every field must be present and not null.
-     */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = Optional.of(address);
-        this.tags.addAll(tags);
-    }
+    private final ModuleRoleMap moduleRoleMap;
 
     /**
      * Every field must be present and not null.
@@ -48,6 +38,20 @@ public class Person {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.moduleRoleMap = new ModuleRoleMap(new HashMap<>());
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Person(Name name, Phone phone, Email email, Optional<Address> address, Set<Tag> tags, ModuleRoleMap moduleRoleMap) {
+        requireAllNonNull(name, phone, email, tags, moduleRoleMap);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.moduleRoleMap = moduleRoleMap;
     }
 
     public Name getName() {
@@ -64,6 +68,10 @@ public class Person {
 
     public Optional<Address> getAddress() {
         return address;
+    }
+
+    public ModuleRoleMap getModuleRoleMap() {
+        return moduleRoleMap;
     }
 
     /**
@@ -107,13 +115,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && moduleRoleMap.equals((otherPerson.moduleRoleMap));
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, moduleRoleMap);
     }
 
     @Override
@@ -124,7 +133,8 @@ public class Person {
                 .add("email", email);
 
         address.ifPresent(addr -> builder.add("address", addr));
-        builder.add("tags", tags);
+        builder.add("tags", tags)
+                .add("roles", moduleRoleMap);
 
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -44,7 +44,8 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Optional<Address> address, Set<Tag> tags, ModuleRoleMap moduleRoleMap) {
+    public Person(Name name, Phone phone, Email email, Optional<Address> address, Set<Tag> tags,
+                  ModuleRoleMap moduleRoleMap) {
         requireAllNonNull(name, phone, email, tags, moduleRoleMap);
         this.name = name;
         this.phone = phone;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.model.util;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -10,12 +9,9 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.ModuleCode;
-import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.RoleType;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,6 +1,8 @@
 package seedu.address.model.util;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -8,9 +10,12 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.ModuleCode;
+import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.RoleType;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -20,22 +25,22 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
+                Optional.of(new Address("Blk 30 Geylang Street 29, #06-40")),
                 getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                Optional.of(new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18")),
                 getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                Optional.of(new Address("Blk 11 Ang Mo Kio Street 74, #11-04")),
                 getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                Optional.of(new Address("Blk 436 Serangoon Gardens Street 26, #16-43")),
                 getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
+                Optional.of(new Address("Blk 47 Tampines Street 20, #17-35")),
                 getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
+                Optional.of(new Address("Blk 45 Aljunied Street 85, #11-31")),
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedModuleRoleMap.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModuleRoleMap.java
@@ -14,6 +14,9 @@ import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.RoleType;
 
+/**
+ * Jackson-friendly version of {@link ModuleRoleMap}.
+ */
 public class JsonAdaptedModuleRoleMap {
     private final Map<String, String> moduleRoleMap;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedModuleRoleMap.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModuleRoleMap.java
@@ -1,0 +1,66 @@
+package seedu.address.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.ModuleCode;
+import seedu.address.model.person.ModuleRoleMap;
+import seedu.address.model.person.RoleType;
+
+public class JsonAdaptedModuleRoleMap {
+    private final Map<String, String> moduleRoleMap;
+
+    /**
+     * Constructs a {@code JsonAdaptedModuleRoleMap} from the given {@code moduleRoleMap} in Json format.
+     */
+    @JsonCreator
+    public JsonAdaptedModuleRoleMap(Map<String, String> moduleRoleMap) {
+        this.moduleRoleMap = moduleRoleMap;
+    }
+
+    /**
+     * Converts a given {@code ModuleRoleMap} into this class for Jackson use.
+     */
+    public JsonAdaptedModuleRoleMap(ModuleRoleMap moduleRoleMap) {
+        this.moduleRoleMap =
+                moduleRoleMap.getRoles().entrySet().stream()
+                .collect(Collectors.toMap(entry -> entry.getKey().toString(), entry -> entry.getValue().toString()));
+    }
+
+    /**
+     * Converts a given {@code ModuleRoleMap} into the Json format {@code String}.
+     */
+    private String toJsonString() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jacksonData = objectMapper.writeValueAsString(this.moduleRoleMap);
+
+        return jacksonData;
+    }
+
+    /**
+     * Serializes the JsonAdaptedModuleRoleMap to JSON format.
+     */
+    @JsonValue
+    public Map<String, String> getModuleRoleMapJsonString() {
+        return moduleRoleMap;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted moduleRoleMap object into the model's {@code ModuleRoleMap} object.
+     */
+    public ModuleRoleMap toModelType() throws IllegalValueException {
+        HashMap<ModuleCode, RoleType> map = new HashMap<>();
+        for (String key : moduleRoleMap.keySet()) {
+            map.put(new ModuleCode(key), RoleType.valueOf(moduleRoleMap.get(key).toUpperCase()));
+        }
+
+        return new ModuleRoleMap(map);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedModuleRoleMap.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModuleRoleMap.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.RoleType;
@@ -61,7 +62,7 @@ public class JsonAdaptedModuleRoleMap {
     public ModuleRoleMap toModelType() throws IllegalValueException {
         HashMap<ModuleCode, RoleType> map = new HashMap<>();
         for (String key : moduleRoleMap.keySet()) {
-            map.put(new ModuleCode(key), RoleType.valueOf(moduleRoleMap.get(key).toUpperCase()));
+            map.put(new ModuleCode(key), ParserUtil.parseRoleType(moduleRoleMap.get(key)));
         }
 
         return new ModuleRoleMap(map);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -30,6 +31,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final JsonAdaptedModuleRoleMap moduleRoleMap;
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -37,7 +39,7 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+            @JsonProperty("tags") List<JsonAdaptedTag> tags, @JsonProperty("moduleRoleMap") JsonAdaptedModuleRoleMap moduleRoleMap) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -45,6 +47,7 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+        this.moduleRoleMap = moduleRoleMap;
     }
 
     /**
@@ -58,6 +61,7 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        moduleRoleMap = new JsonAdaptedModuleRoleMap(source.getModuleRoleMap());
     }
 
     /**
@@ -102,7 +106,13 @@ class JsonAdaptedPerson {
         final Address modelAddress = address != null ? new Address(address) : null;
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
-        return new Person(modelName, modelPhone, modelEmail, Optional.ofNullable(modelAddress), modelTags);
+        if (moduleRoleMap == null) {
+            throw new IllegalValueException((ModuleRoleMap.MESSAGE_CONSTRAINTS));
+        }
+
+        final ModuleRoleMap modelModuleRoleMap = moduleRoleMap.toModelType();
+
+        return new Person(modelName, modelPhone, modelEmail, Optional.ofNullable(modelAddress), modelTags, modelModuleRoleMap);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -38,8 +38,9 @@ class JsonAdaptedPerson {
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags, @JsonProperty("moduleRoleMap") JsonAdaptedModuleRoleMap moduleRoleMap) {
+                             @JsonProperty("email") String email, @JsonProperty("address") String address,
+                             @JsonProperty("tags") List<JsonAdaptedTag> tags,
+                             @JsonProperty("moduleRoleMap") JsonAdaptedModuleRoleMap moduleRoleMap) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -57,9 +58,9 @@ class JsonAdaptedPerson {
         name = source.getName().fullName;
         phone = source.getPhone().value;
         email = source.getEmail().value;
-        address = source.getAddress().map(Object::toString).orElse(null);
+        address = source.getAddress().map(Object :: toString).orElse(null);
         tags.addAll(source.getTags().stream()
-                .map(JsonAdaptedTag::new)
+                .map(JsonAdaptedTag :: new)
                 .collect(Collectors.toList()));
         moduleRoleMap = new JsonAdaptedModuleRoleMap(source.getModuleRoleMap());
     }
@@ -112,7 +113,12 @@ class JsonAdaptedPerson {
 
         final ModuleRoleMap modelModuleRoleMap = moduleRoleMap.toModelType();
 
-        return new Person(modelName, modelPhone, modelEmail, Optional.ofNullable(modelAddress), modelTags, modelModuleRoleMap);
+        return new Person(modelName,
+                modelPhone,
+                modelEmail,
+                Optional.ofNullable(modelAddress),
+                modelTags,
+                modelModuleRoleMap);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -108,7 +108,7 @@ class JsonAdaptedPerson {
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
         if (moduleRoleMap == null) {
-            throw new IllegalValueException((ModuleRoleMap.MESSAGE_CONSTRAINTS));
+            throw new IllegalValueException(ModuleRoleMap.MESSAGE_CONSTRAINTS);
         }
 
         final ModuleRoleMap modelModuleRoleMap = moduleRoleMap.toModelType();

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -4,11 +4,13 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
-    "tags": [ "friends" ]
+    "tags": [ "friends" ],
+    "moduleRoleMap" : {}
   }, {
     "name": "Alice Yeo",
     "phone": "94351253",
     "email": "alice@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "moduleRoleMap" : {}
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -1,46 +1,68 @@
 {
   "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
-  "persons" : [ {
-    "name" : "Alice Pauline",
-    "phone" : "94351253",
-    "email" : "alice@example.com",
-    "address" : "123, Jurong West Ave 6, #08-111",
-    "tags" : [ "friends" ]
-  }, {
-    "name" : "Benson Meier",
-    "phone" : "98765432",
-    "email" : "johnd@example.com",
-    "address" : "311, Clementi Ave 2, #02-25",
-    "tags" : [ "owesMoney", "friends" ]
-  }, {
-    "name" : "Carl Kurz",
-    "phone" : "95352563",
-    "email" : "heinz@example.com",
-    "address" : "wall street",
-    "tags" : [ ]
-  }, {
-    "name" : "Daniel Meier",
-    "phone" : "87652533",
-    "email" : "cornelia@example.com",
-    "address" : "10th street",
-    "tags" : [ "friends" ]
-  }, {
-    "name" : "Elle Meyer",
-    "phone" : "9482224",
-    "email" : "werner@example.com",
-    "address" : "michegan ave",
-    "tags" : [ ]
-  }, {
-    "name" : "Fiona Kunz",
-    "phone" : "9482427",
-    "email" : "lydia@example.com",
-    "address" : "little tokyo",
-    "tags" : [ ]
-  }, {
-    "name" : "George Best",
-    "phone" : "9482442",
-    "email" : "anna@example.com",
-    "address" : null,
-    "tags" : [ ]
-  } ]
+  "persons": [
+    {
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tags": [
+        "friends"
+      ],
+      "moduleRoleMap": {}
+    },
+    {
+      "name": "Benson Meier",
+      "phone": "98765432",
+      "email": "johnd@example.com",
+      "address": "311, Clementi Ave 2, #02-25",
+      "tags": [
+        "owesMoney",
+        "friends"
+      ],
+      "moduleRoleMap": {"CS1101S" :  "TUTOR", "CS2040S" :  "STUDENT"}
+    },
+    {
+      "name": "Carl Kurz",
+      "phone": "95352563",
+      "email": "heinz@example.com",
+      "address": "wall street",
+      "tags": [],
+      "moduleRoleMap": {}
+    },
+    {
+      "name": "Daniel Meier",
+      "phone": "87652533",
+      "email": "cornelia@example.com",
+      "address": "10th street",
+      "tags": [
+        "friends"
+      ],
+      "moduleRoleMap": {}
+    },
+    {
+      "name": "Elle Meyer",
+      "phone": "9482224",
+      "email": "werner@example.com",
+      "address": "michegan ave",
+      "tags": [],
+      "moduleRoleMap": {}
+    },
+    {
+      "name": "Fiona Kunz",
+      "phone": "9482427",
+      "email": "lydia@example.com",
+      "address": "little tokyo",
+      "tags": [],
+      "moduleRoleMap": {}
+    },
+    {
+      "name": "George Best",
+      "phone": "9482442",
+      "email": "anna@example.com",
+      "address": null,
+      "tags": [],
+      "moduleRoleMap": {}
+    }
+  ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -27,16 +27,20 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
 public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
+    public static final String VALID_NAME_ANDY = "Andy";
     public static final String VALID_NAME_BETTY = "Betty";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
+    public static final String VALID_PHONE_ANDY = "12345678";
     public static final String VALID_PHONE_BETTY = "98765432";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_ALICE = "alice@example.com";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
+    public static final String VALID_EMAIL_ANDY = "andy@example.com";
     public static final String VALID_EMAIL_BETTY = "johnd@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
+    public static final String VALID_ADDRESS_ANDY = "Block 567, Andy Street 2";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.testutil.Assert;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonTest {

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.ANDY;
 import static seedu.address.testutil.TypicalPersons.BETTY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.CARL;
@@ -21,9 +22,31 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.testutil.Assert;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonTest {
+
+    @Test
+    public void testPersonConstructorWithModuleRoleMap() {
+        Person andy = new PersonBuilder(ANDY).build();
+
+        Person person = new Person(ANDY.getName(), ANDY.getPhone(), ANDY.getEmail(), ANDY.getAddress(),
+                ANDY.getTags(), ANDY.getModuleRoleMap());
+        assertNotNull(person, "The person object should not be null");
+        assertEquals(andy, person);
+    }
+
+    @Test
+    public void testPersonConstructorWithoutModuleRoleMap() {
+        Person betty = new PersonBuilder(BETTY).build();
+
+        Person person = new Person(BETTY.getName(), BETTY.getPhone(), BETTY.getEmail(),
+                Optional.empty(), BETTY.getTags());
+
+        assertNotNull(person, "The person object should not be null");
+        assertEquals(betty, person);
+    }
 
     @Test
     public void asObservableList_modifyList_throwsUnsupportedOperationException() {
@@ -119,7 +142,8 @@ public class PersonTest {
                 + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail()
                 + ", address=" + ALICE.getAddress().map(Objects ::toString).orElse(null)
-                + ", tags=" + ALICE.getTags() + "}";
+                + ", tags=" + ALICE.getTags()
+                + ", roles=" + ALICE.getModuleRoleMap() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -8,22 +8,16 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BETTY;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import javax.management.relation.Role;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.ModuleCode;
-import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.RoleType;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -36,11 +30,11 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_NAME2 = BETTY.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
-    private static final String VALID_ADDRESS = BENSON.getAddress().map(Object::toString).orElse(null);
+    private static final String VALID_ADDRESS = BENSON.getAddress().map(Object :: toString).orElse(null);
     private static final JsonAdaptedModuleRoleMap VALID_EMPTY_MODULE_ROLE_MAP =
             new JsonAdaptedModuleRoleMap(ALICE.getModuleRoleMap());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
-            .map(JsonAdaptedTag::new)
+            .map(JsonAdaptedTag :: new)
             .collect(Collectors.toList());
 
     @Test
@@ -62,7 +56,7 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
                         VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person :: toModelType);
     }
 
     @Test
@@ -70,7 +64,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person :: toModelType);
     }
 
     @Test
@@ -79,7 +73,7 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
                         VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person :: toModelType);
     }
 
     @Test
@@ -87,7 +81,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
                 VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person :: toModelType);
     }
 
     @Test
@@ -96,7 +90,7 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
                         VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person :: toModelType);
     }
 
     @Test
@@ -104,7 +98,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
                 VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person :: toModelType);
     }
 
     @Test
@@ -113,7 +107,7 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
                         VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person :: toModelType);
     }
 
     @Test
@@ -123,6 +117,6 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags,
                         VALID_EMPTY_MODULE_ROLE_MAP);
-        assertThrows(IllegalValueException.class, person::toModelType);
+        assertThrows(IllegalValueException.class, person :: toModelType);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BETTY;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -117,6 +118,17 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags,
                         VALID_EMPTY_MODULE_ROLE_MAP);
+        assertThrows(IllegalValueException.class, person :: toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidRoleTypeInModuleRoleMap_throwsIllegalValueException() {
+        HashMap<String, String> invalidMap = new HashMap<>();
+        invalidMap.put("CS1101S", "invalid string");
+        JsonAdaptedModuleRoleMap invalidJsonMap = new JsonAdaptedModuleRoleMap(invalidMap);
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        invalidJsonMap);
         assertThrows(IllegalValueException.class, person :: toModelType);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -3,20 +3,27 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BETTY;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import javax.management.relation.Role;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.ModuleCode;
+import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.RoleType;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -30,6 +37,8 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().map(Object::toString).orElse(null);
+    private static final JsonAdaptedModuleRoleMap VALID_EMPTY_MODULE_ROLE_MAP =
+            new JsonAdaptedModuleRoleMap(ALICE.getModuleRoleMap());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -42,21 +51,24 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_nullAddress_returnsPerson() throws Exception {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME2, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME2, VALID_PHONE, VALID_EMAIL, null,
+                VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         assertEquals(BETTY, person.toModelType());
     }
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -64,14 +76,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -79,14 +93,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
+                VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -94,7 +110,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
+                        VALID_TAGS, VALID_EMPTY_MODULE_ROLE_MAP);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -104,8 +121,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags,
+                        VALID_EMPTY_MODULE_ROLE_MAP);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
-
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,14 +1,18 @@
 package seedu.address.testutil;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.ModuleCode;
+import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.RoleType;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -27,6 +31,7 @@ public class PersonBuilder {
     private Email email;
     private Optional<Address> address;
     private Set<Tag> tags;
+    private ModuleRoleMap moduleRoleMap;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -37,6 +42,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = Optional.of(new Address(DEFAULT_ADDRESS));
         tags = new HashSet<>();
+        moduleRoleMap = new ModuleRoleMap(new HashMap<ModuleCode, RoleType>());
     }
 
     /**
@@ -48,6 +54,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
+        moduleRoleMap = personToCopy.getModuleRoleMap();
     }
 
     /**
@@ -63,6 +70,26 @@ public class PersonBuilder {
      */
     public PersonBuilder withTags(String ... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Parses the {@code ModuleRoleMap} into a {@code ModuleRoleMap} and set it to the {@code Person}
+     * that we are building.
+     */
+    public PersonBuilder withModuleRoleMap(ModuleCode moduleCode, RoleType roleType) {
+        HashMap<ModuleCode, RoleType> moduleRoleMap = new HashMap<>();
+        moduleRoleMap.put(moduleCode, roleType);
+        this.moduleRoleMap = new ModuleRoleMap(moduleRoleMap);
+        return this;
+    }
+
+    /**
+     * Parses the {@code ModuleRoleMap} into a {@code ModuleRoleMap} and set it to the {@code Person}
+     * that we are building.
+     */
+    public PersonBuilder withModuleRoleMap(ModuleCode[] moduleCodes, RoleType[] roleTypes) {
+        this.moduleRoleMap = new ModuleRoleMap(moduleCodes, roleTypes);
         return this;
     }
 
@@ -105,14 +132,14 @@ public class PersonBuilder {
      * Builds the {@code Person} that we are testing.
      */
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, moduleRoleMap);
     }
 
     /**
      * Builds the {@code Person} that we are testing without address.
      */
     public Person buildEmptyAddressPerson() {
-        return new Person(name, phone, email, Optional.empty(), tags);
+        return new Person(name, phone, email, Optional.empty(), tags, moduleRoleMap);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -1,14 +1,18 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_ANDY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_ANDY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BETTY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_ANDY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BETTY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_ANDY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BETTY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
@@ -16,10 +20,15 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
+import javax.management.relation.Role;
+
 import seedu.address.model.AddressBook;
+import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.RoleType;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
@@ -33,7 +42,10 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends")
+            .withModuleRoleMap(
+                    new ModuleCode[] {new ModuleCode("CS1101S"), new ModuleCode("CS2040S")},
+                    new RoleType[] {RoleType.TUTOR, RoleType.STUDENT}).build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
@@ -52,6 +64,10 @@ public class TypicalPersons {
             .withEmail("hans@example.com").withAddress("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
+    public static final Person ANDY = new PersonBuilder().withName(VALID_NAME_ANDY)
+            .withEmail(VALID_EMAIL_ANDY).withPhone(VALID_PHONE_ANDY).withAddress(VALID_ADDRESS_ANDY)
+            .withTags("owesMoney", "friends").withModuleRoleMap(new ModuleCode("CS1101S"), RoleType.STUDENT).build();
+
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -20,10 +20,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-
-import javax.management.relation.Role;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.ModuleCode;
@@ -80,7 +77,8 @@ public class TypicalPersons {
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
-    private TypicalPersons() {} // prevents instantiation
+    private TypicalPersons() {
+    } // prevents instantiation
 
     /**
      * Returns an {@code AddressBook} with all the typical persons.


### PR DESCRIPTION
Closes #73 

The HashMap<ModuleCode, RoleType> is converted to HashMap<String, String> in the JsonAdaptedModuleRoleMap to parse the data into Json format.

Not sure if this is the best way, but in order to make the conversion mentioned above, I added a method ``getRoles()`` inside ModuleRoleMap to fetch the HashMap.

The data is being saved in the format as:
```
"moduleRoleMap": {"CS1101S" :  "TUTOR", "CS2040S" :  "STUDENT"}
```
If the person added does not belong to any module, then it would be 
```
"moduleRoleMap": {}
```
The ``RoleType`` in the Json data only accepts the String value of Enum of RoleType.