### PR TITLE
Update UG repetition syntax

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -54,9 +54,12 @@
 * Items in square brackets are optional.<br>
   e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 
-* Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
+* Items in sqaure brackets and with `+`​ after them can be used zero or more times.<br>
+  e.g. `[t/TAG]+​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
+* Items in **round** brackets and with `+`​ after them can be used one or more times.<br>
+  e.g. `(t/TAG)+​` can be used as `t/friend`, `t/friend t/family` etc.
+* 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
@@ -79,7 +82,7 @@ Format: `help`
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL [a/ADDRESS] [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL [a/ADDRESS] [t/TAG]+​`
 
 <box type="tip" seamless>
 
@@ -106,7 +109,7 @@ Format: `list`
 
 Edits an existing person in the address book.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]+​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -123,7 +126,7 @@ Examples:
 
 Finds persons whose names contain any of the given keywords.
 
-Format: `find n/KEYWORD [n/MORE_KEYWORDS]`
+Format: `find (n/KEYWORD)+`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * Each keyword can contain multiple words. e.g. `John Doe`
@@ -142,7 +145,7 @@ Examples:
 
 Deletes the specified person from the address book.
 
-Format: `delete INDEX [MORE_INDICES]...`
+Format: `delete (INDEX)+`
 
 * Deletes the person(s) at the specified INDEX(es).
 * The index refers to the index number shown in the displayed person list.
@@ -203,10 +206,10 @@ _Details coming soon ..._
 
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL [a/ADDRESS] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
+**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL [a/ADDRESS] [t/TAG]+` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
 **Clear**  | `clear`
-**Delete** | `delete INDEX [MORE_INDICES]...`<br> e.g., `delete 3` or `delete 1 3 5`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
-**Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
+**Delete** | `delete (INDEX)+`<br> e.g., `delete 3` or `delete 1 3 5`
+**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]+`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Find**   | `find (n/KEYWORD)+`<br> e.g., `find James Jake`
 **List**   | `list`
 **Help**   | `help`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,7 +59,7 @@
 
 * Items in **round** brackets and with `+`​ after them can be used one or more times.<br>
   e.g. `(t/TAG)+​` can be used as `t/friend`, `t/friend t/family` etc.
-* 
+
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 


### PR DESCRIPTION
Change syntax for repeated elements from ... to +, so that from now onwards,
* Items in square brackets are optional.<br>
  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.

* Items in sqaure brackets and with `+`​ after them can be used zero or more times.<br>
  e.g. `[t/TAG]+​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.

* Items in **round** brackets and with `+`​ after them can be used one or more times.<br>
  e.g. `(t/TAG)+​` can be used as `t/friend`, `t/friend t/family` etc.
