### PR TITLE
Update GUI

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -29,7 +29,6 @@ public class PersonCard extends UiPart<Region> {
      * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
      */
 
-
     private static final Image studentIcon =
         new Image(MainApp.class.getResourceAsStream("/images/role-icons/student.png"));
     private static final Image tutorIcon =
@@ -61,7 +60,6 @@ public class PersonCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
 
-
         if (person.hasPhone()) {
             Label phone = new Label(person.getPhone().map(Object::toString).orElse(null));
             phone.getStyleClass().add("cell_small_label");
@@ -82,6 +80,7 @@ public class PersonCard extends UiPart<Region> {
             address.setText(person.getAddress().orElse(null).value);
             vBox.getChildren().add(address);
         }
+
         // Add tags
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -8,6 +8,7 @@
     -fx-font-family: "Segoe UI Semibold";
     -fx-text-fill: #555555;
     -fx-opacity: 0.9;
+    -fx-wrap-text: true;
 }
 
 .label-bright {

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -14,7 +14,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox id="vBox" fx:id="vBox" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox id="vBox" fx:id="vBox" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" spacing="2">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -18,7 +18,7 @@
       <padding>
         <Insets top="5" right="15" bottom="5" left="15" />
       </padding>
-      <HBox spacing="0.5" alignment="CENTER_LEFT">
+      <HBox spacing="0.5" alignment="TOP_LEFT" >
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -16,7 +16,7 @@
     </columnConstraints>
     <VBox id="vBox" fx:id="vBox" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" spacing="2">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets top="5" right="15" bottom="5" left="15" />
       </padding>
       <HBox spacing="0.5" alignment="CENTER_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">


### PR DESCRIPTION
Fixes #126, and adds vertical padding between elements so that the tags and roles are separated

### Before

![image](https://github.com/user-attachments/assets/831e6e16-d0d1-45c6-8cd9-05fe2b050afe)

### After

![image](https://github.com/user-attachments/assets/c7a46d5c-8fa6-4273-8eaa-6b63744a10b8)
