### PR TITLE
Update uml diagram for storage

### DIFF
--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -20,6 +20,7 @@ Class JsonAddressBookStorage
 Class JsonSerializableAddressBook
 Class JsonAdaptedPerson
 Class JsonAdaptedTag
+Class JsonAdaptedModuleRoleMap
 }
 
 }
@@ -39,5 +40,7 @@ JsonAddressBookStorage .up.|> AddressBookStorage
 JsonAddressBookStorage ..> JsonSerializableAddressBook
 JsonSerializableAddressBook --> "*" JsonAdaptedPerson
 JsonAdaptedPerson --> "*" JsonAdaptedTag
+JsonAdaptedPerson -> "1" JsonAdaptedModuleRoleMap
+JsonAdaptedTag -right[hidden]- JsonAdaptedModuleRoleMap
 
 @enduml


### PR DESCRIPTION
The multiplicity of JsonAdaptedModuleRoleMap is 1 because the empty ``ModuleRoleMap`` will still be passed to it even if the contact does not have a ``ModuleRoleMap``.

Change from:
![image](https://github.com/user-attachments/assets/68710a22-7d6b-409a-b83a-fc32aa98186d)

To:
![image](https://github.com/user-attachments/assets/15d9cb6a-e6bb-4317-9367-4a9de96db7ed)
