### PR TITLE
Edit module role now fails explicitly

### DIFF
--- a/src/main/java/seedu/address/logic/commands/edit/AddModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/AddModuleRoleOperation.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.RoleType;
@@ -30,10 +31,14 @@ public class AddModuleRoleOperation extends EditModuleRoleOperation {
      * @return A new ModuleRoleMap with module role pairs added.
      */
     @Override
-    protected ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit) {
+    protected ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit) throws CommandException {
         HashMap<ModuleCode, RoleType> roles = new HashMap<>(moduleRoleMapToEdit.getRoles());
         ModuleRoleMap ret = new ModuleRoleMap(roles);
-        ret.putAll(moduleRoleMapToAdd);
+        ModuleRoleMap failed = ret.putAll(moduleRoleMapToAdd);
+        if (!failed.isEmpty()) {
+            throw new CommandException("You wish to add these module role pair(s) but they clash with existing ones: "
+                    + failed.getData());
+        }
         logger.info("Added module roles: " + moduleRoleMapToAdd.getData()
                 + "to: " + moduleRoleMapToEdit.getData());
         return ret;

--- a/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.RoleType;
@@ -30,10 +32,14 @@ public class DeleteModuleRoleOperation extends EditModuleRoleOperation {
      * @return A new ModuleRoleMap with module role pairs deleted.
      */
     @Override
-    protected ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit) {
+    protected ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit) throws CommandException {
         HashMap<ModuleCode, RoleType> roles = new HashMap<>(moduleRoleMapToEdit.getRoles());
         ModuleRoleMap ret = new ModuleRoleMap(roles);
-        ret.removeAll(moduleRoleMapToDelete);
+        ModuleRoleMap failed = ret.removeAll(moduleRoleMapToDelete);
+        if (!failed.isEmpty()) {
+            throw new CommandException("You wish to delete these module role pair(s) but they do not exist: "
+                    + failed.getData());
+        }
         logger.info("Deleted module roles: " + moduleRoleMapToDelete.getData()
                 + "from: " + moduleRoleMapToEdit.getData());
         return ret;

--- a/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;

--- a/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
@@ -91,9 +91,10 @@ public class EditCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        String changeDescription = getChangesDescription(personToEdit, editedPerson);
+        String changesDescription = getChangesDescription(personToEdit, editedPerson);
+
         return new CommandResult(
-                String.format(MESSAGE_EDIT_PERSON_SUCCESS, changeDescription, Messages.format(editedPerson)));
+                String.format(MESSAGE_EDIT_PERSON_SUCCESS, changesDescription, Messages.format(editedPerson)));
     }
 
     /**
@@ -120,41 +121,41 @@ public class EditCommand extends Command {
      * Returns a description of the changes made to the person.
      */
     public static String getChangesDescription(Person personBefore, Person personAfter) {
-        StringBuilder changeDescription = new StringBuilder("Change(s) made: \n");
+        StringBuilder changesDescription = new StringBuilder("Change(s) made: \n");
         boolean isChanged = false;
         if (!personBefore.getName().equals(personAfter.getName())) {
             isChanged = true;
-            changeDescription.append("Name: ").append(personBefore.getName()).append(" -> ")
+            changesDescription.append("Name: ").append(personBefore.getName()).append(" -> ")
                     .append(personAfter.getName()).append("\n");
         }
         if (!personBefore.getPhone().equals(personAfter.getPhone())) {
             isChanged = true;
-            changeDescription.append("Phone: ").append(personBefore.getPhone()).append(" -> ")
+            changesDescription.append("Phone: ").append(personBefore.getPhone()).append(" -> ")
                     .append(personAfter.getPhone()).append("\n");
         }
         if (!personBefore.getEmail().equals(personAfter.getEmail())) {
             isChanged = true;
-            changeDescription.append("Email: ").append(personBefore.getEmail()).append(" -> ")
+            changesDescription.append("Email: ").append(personBefore.getEmail()).append(" -> ")
                     .append(personAfter.getEmail()).append("\n");
         }
         if (!personBefore.getAddress().equals(personAfter.getAddress())) {
             isChanged = true;
-            changeDescription.append("Address: ")
+            changesDescription.append("Address: ")
                     .append(personBefore.getAddress().map(Object::toString).orElse("<no address>")).append(" -> ")
                     .append(personAfter.getAddress().map(Object::toString).orElse("<no address>")).append("\n");
         }
         if (!personBefore.getTags().equals(personAfter.getTags())) {
             isChanged = true;
-            changeDescription.append("Tags: ").append(personBefore.getTags()).append(" -> ")
+            changesDescription.append("Tags: ").append(personBefore.getTags()).append(" -> ")
                     .append(personAfter.getTags()).append("\n");
         }
         if (!personBefore.getModuleRoleMap().equals(personAfter.getModuleRoleMap())) {
             isChanged = true;
-            changeDescription.append(EditModuleRoleOperation.getModuleCodeChangeDescription(
+            changesDescription.append(EditModuleRoleOperation.getModuleCodeChangesDescription(
                     personBefore.getModuleRoleMap(), personAfter.getModuleRoleMap())).append("\n");
         }
 
-        return isChanged ? changeDescription.toString() : "No changes made.";
+        return isChanged ? changesDescription.toString() : "No changes made.";
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
@@ -50,7 +50,7 @@ public abstract class EditModuleRoleOperation {
      * @param moduleRoleMapAfter The module role map after the change.
      * @return A description of the change in module roles.
      */
-    public static String getModuleCodeChangeDescription(
+    public static String getModuleCodeChangesDescription(
             ModuleRoleMap moduleRoleMapBefore, ModuleRoleMap moduleRoleMapAfter) {
 
         StringBuilder stringBuilderAdded = new StringBuilder();

--- a/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.edit;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.ModuleRolePair;
@@ -27,7 +28,7 @@ public abstract class EditModuleRoleOperation {
      * @param moduleRoleMapToEdit The module role map to edit.
      * @return The module role map after the operation.
      */
-    protected abstract ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit);
+    protected abstract ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit) throws CommandException;
 
     /**
      * Checks if the given operation is a valid module role operation.

--- a/src/test/java/seedu/address/logic/commands/edit/AddModuleRoleOperationTest.java
+++ b/src/test/java/seedu/address/logic/commands/edit/AddModuleRoleOperationTest.java
@@ -2,9 +2,12 @@ package seedu.address.logic.commands.edit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.RoleType;
@@ -40,46 +43,55 @@ public class AddModuleRoleOperationTest {
     public void execute_addsModuleRolePairs_success() {
         // Add single module role pair
         ModuleRoleMap initialMap = new ModuleRoleMap(
-                new ModuleCode[]{new ModuleCode("CS1101S")}, new RoleType[]{RoleType.STUDENT});
+                new ModuleCode[]{new ModuleCode("CS1101S")},
+                new RoleType[]{RoleType.STUDENT});
         ModuleRoleMap mapToAdd = new ModuleRoleMap(
-                new ModuleCode[]{new ModuleCode("CS2103T")}, new RoleType[]{RoleType.TUTOR});
+                new ModuleCode[]{new ModuleCode("CS2103T")},
+                new RoleType[]{RoleType.TUTOR});
+
         ModuleRoleMap expectedMap = DEFAULT_MODULE_ROLE_MAP;
 
-        assertEquals(expectedMap, new AddModuleRoleOperation(mapToAdd).execute(initialMap));
+        try {
+            assertEquals(expectedMap, new AddModuleRoleOperation(mapToAdd).execute(initialMap));
+        } catch (CommandException e) {
+            fail("CommandException should not be thrown.");
+        }
 
         // Add multiple module role pairs
         initialMap = new ModuleRoleMap(new ModuleCode[]{}, new RoleType[]{});
         mapToAdd = new ModuleRoleMap(DEFAULT_MODULE_CODES, DEFAULT_ROLE_TYPES);
 
-        assertEquals(expectedMap, new AddModuleRoleOperation(mapToAdd).execute(initialMap));
+        try {
+            assertEquals(expectedMap, new AddModuleRoleOperation(mapToAdd).execute(initialMap));
+        } catch (CommandException e) {
+            fail("CommandException should not be thrown.");
+        }
     }
 
     @Test
     public void execute_addsModuleRolePairs_failure() {
-        // Add module role pair already exists -> returns same map
+        // Add module role pair already exists -> throws CommandException
         ModuleRoleMap initialMap = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS1101S")}, new RoleType[]{RoleType.STUDENT});
-        ModuleRoleMap mapToAdd = initialMap;
-        ModuleRoleMap expectedMap = initialMap;
+        final ModuleRoleMap mapToAdd1 = initialMap;
 
-        assertEquals(expectedMap, new AddModuleRoleOperation(mapToAdd).execute(initialMap));
+        assertThrows(CommandException.class, () -> new AddModuleRoleOperation(mapToAdd1).execute(initialMap));
 
         // Add module role pair having same module code but different role as pre-existing one -> returns same map
-        mapToAdd = new ModuleRoleMap(
+        final ModuleRoleMap mapToAdd2 = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS1101S")}, new RoleType[]{RoleType.TUTOR});
 
-        assertEquals(expectedMap, new AddModuleRoleOperation(mapToAdd).execute(initialMap));
+        assertThrows(CommandException.class, () -> new AddModuleRoleOperation(mapToAdd2).execute(initialMap));
     }
 
     @Test
-    public void execute_addsModuleRolePairs_partialSuccess() {
-        // Add multiple module role pairs, some already exist
+    public void execute_addsModuleRolePairs_partialFailure() {
+        // Add multiple module role pairs, some already exist -> throws CommandException
         ModuleRoleMap initialMap = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS1101S")}, new RoleType[]{RoleType.STUDENT});
         ModuleRoleMap mapToAdd = new ModuleRoleMap(DEFAULT_MODULE_CODES, DEFAULT_ROLE_TYPES);
-        ModuleRoleMap expectedMap = DEFAULT_MODULE_ROLE_MAP;
 
-        assertEquals(expectedMap, new AddModuleRoleOperation(mapToAdd).execute(initialMap));
+        assertThrows(CommandException.class, () -> new AddModuleRoleOperation(mapToAdd).execute(initialMap));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperationTest.java
+++ b/src/test/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperationTest.java
@@ -2,9 +2,12 @@ package seedu.address.logic.commands.edit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.RoleType;
@@ -51,7 +54,11 @@ public class DeleteModuleRoleOperationTest {
         ModuleRoleMap expectedMap = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS1101S")}, new RoleType[]{RoleType.STUDENT});
 
-        assertEquals(expectedMap, new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
+        try {
+            assertEquals(expectedMap, new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
+        } catch (CommandException e) {
+            fail("CommandException should not be thrown.");
+        }
 
         // Delete multiple module role pairs
         initialMap = new ModuleRoleMap(
@@ -66,31 +73,34 @@ public class DeleteModuleRoleOperationTest {
         expectedMap = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("MA1522")}, new RoleType[]{RoleType.PROFESSOR});
 
-        assertEquals(expectedMap, new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
+        try {
+            assertEquals(expectedMap, new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
+        } catch (CommandException e) {
+            fail("CommandException should not be thrown.");
+        }
     }
 
     @Test
     public void execute_deletesModuleRolePairs_failure() {
-        // Delete non-existent module role pairs -> returns the same map
+        // Delete non-existent module role pairs -> throws CommandException
         ModuleRoleMap initialMap = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS1101S")}, new RoleType[]{RoleType.STUDENT});
 
-        ModuleRoleMap mapToDelete = new ModuleRoleMap(
+        final ModuleRoleMap mapToDelete1 = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS2103T")}, new RoleType[]{RoleType.TUTOR});
-        ModuleRoleMap expectedMap = initialMap;
 
-        assertEquals(expectedMap, new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
+        assertThrows(CommandException.class, () -> new DeleteModuleRoleOperation(mapToDelete1).execute(initialMap));
 
         // Delete module role pair having same module code but different role as pre-existing one -> returns same map
-        mapToDelete = new ModuleRoleMap(
+        final ModuleRoleMap mapToDelete2 = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS1101S")}, new RoleType[]{RoleType.TUTOR});
 
-        assertEquals(expectedMap, new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
+        assertThrows(CommandException.class, () -> new DeleteModuleRoleOperation(mapToDelete2).execute(initialMap));
     }
 
     @Test
-    public void execute_deletesModuleRolePairs_partialSuccess() {
-        // Delete multiple module role pairs, some do not exist
+    public void execute_deletesModuleRolePairs_partialFailure() {
+        // Delete multiple module role pairs, some do not exist -> throws CommandException
         ModuleRoleMap initialMap = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS1101S"), new ModuleCode("CS2103T"), new ModuleCode("MA1522")},
                 new RoleType[]{RoleType.STUDENT, RoleType.TUTOR, RoleType.PROFESSOR});
@@ -103,7 +113,7 @@ public class DeleteModuleRoleOperationTest {
                 new ModuleCode[]{new ModuleCode("CS2103T"), new ModuleCode("MA1522")},
                 new RoleType[]{RoleType.TUTOR, RoleType.PROFESSOR});
 
-        assertEquals(expectedMap, new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
+        assertThrows(CommandException.class, () -> new DeleteModuleRoleOperation(mapToDelete).execute(initialMap));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/edit/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/edit/EditCommandTest.java
@@ -223,7 +223,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void getChangeDescription_hasChanges_success() {
+    public void getChangesDescription_hasChanges_success() {
         // changed all fields
         Person person = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).withEmptyAddress()
@@ -240,7 +240,7 @@ public class EditCommandTest {
                 + "\nAddress: " + person.getAddress().map(Object::toString).orElse("<no address>")
                 + " -> " + editedPerson.getAddress().map(Object::toString).orElse("<no address>")
                 + "\nTags: " + person.getTags() + " -> " + editedPerson.getTags()
-                + "\n" + EditModuleRoleOperation.getModuleCodeChangeDescription(
+                + "\n" + EditModuleRoleOperation.getModuleCodeChangesDescription(
                         person.getModuleRoleMap(),
                         editedPerson.getModuleRoleMap()) + "\n";
 
@@ -248,7 +248,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void getChangeDescription_noChanges_success() {
+    public void getChangesDescription_noChanges_success() {
         Person person = new PersonBuilder().build();
         String expected = "No changes made.";
         assertEquals(expected, EditCommand.getChangesDescription(person, person));

--- a/src/test/java/seedu/address/logic/commands/edit/EditModuleRoleOperationTest.java
+++ b/src/test/java/seedu/address/logic/commands/edit/EditModuleRoleOperationTest.java
@@ -37,12 +37,12 @@ public class EditModuleRoleOperationTest {
     }
 
     @Test
-    public void getModuleCodeChangeDescription_noChange_success() {
+    public void getModuleCodeChangesDescription_noChange_success() {
         ModuleRoleMap moduleRoleMapBefore = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS2103T"), new ModuleCode("CS2101")},
                 new RoleType[]{RoleType.STUDENT, RoleType.TUTOR}
         );
-        String actualDescription = EditModuleRoleOperation.getModuleCodeChangeDescription(
+        String actualDescription = EditModuleRoleOperation.getModuleCodeChangesDescription(
                 moduleRoleMapBefore, moduleRoleMapBefore
         );
         String expectedDescription = "";
@@ -50,7 +50,7 @@ public class EditModuleRoleOperationTest {
     }
 
     @Test
-    public void getModuleCodeChangeDescription_addedOnly_success() {
+    public void getModuleCodeChangesDescription_addedOnly_success() {
         ModuleRoleMap moduleRoleMapBefore = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS2103T"), new ModuleCode("CS2101")},
                 new RoleType[]{RoleType.STUDENT, RoleType.TUTOR}
@@ -59,7 +59,7 @@ public class EditModuleRoleOperationTest {
                 new ModuleCode[]{new ModuleCode("CS2103T"), new ModuleCode("CS2101"), new ModuleCode("CS2102")},
                 new RoleType[]{RoleType.STUDENT, RoleType.TUTOR, RoleType.PROFESSOR}
         );
-        String actualDescription = EditModuleRoleOperation.getModuleCodeChangeDescription(
+        String actualDescription = EditModuleRoleOperation.getModuleCodeChangesDescription(
                 moduleRoleMapBefore, moduleRoleMapAfter
         );
         String expectedDescription = "Module role(s) added: "
@@ -68,7 +68,7 @@ public class EditModuleRoleOperationTest {
     }
 
     @Test
-    public void getModuleCodeChangeDescription_deletedOnly_success() {
+    public void getModuleCodeChangesDescription_deletedOnly_success() {
         ModuleRoleMap moduleRoleMapBefore = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS2103T"), new ModuleCode("CS2101")},
                 new RoleType[]{RoleType.STUDENT, RoleType.TUTOR}
@@ -77,7 +77,7 @@ public class EditModuleRoleOperationTest {
                 new ModuleCode[]{new ModuleCode("CS2103T")},
                 new RoleType[]{RoleType.STUDENT}
         );
-        String actualDescription = EditModuleRoleOperation.getModuleCodeChangeDescription(
+        String actualDescription = EditModuleRoleOperation.getModuleCodeChangesDescription(
                 moduleRoleMapBefore, moduleRoleMapAfter
         );
         String expectedDescription = "Module role(s) deleted: "
@@ -86,7 +86,7 @@ public class EditModuleRoleOperationTest {
     }
 
     @Test
-    public void getModuleCodeChangeDescription_addedAndDeleted_success() {
+    public void getModuleCodeChangesDescription_addedAndDeleted_success() {
         ModuleRoleMap moduleRoleMapBefore = new ModuleRoleMap(
                 new ModuleCode[]{new ModuleCode("CS2103T"), new ModuleCode("CS2101")},
                 new RoleType[]{RoleType.STUDENT, RoleType.TUTOR}
@@ -95,7 +95,7 @@ public class EditModuleRoleOperationTest {
                 new ModuleCode[]{new ModuleCode("CS2103T"), new ModuleCode("CS2102")},
                 new RoleType[]{RoleType.STUDENT, RoleType.PROFESSOR}
         );
-        String actualDescription = EditModuleRoleOperation.getModuleCodeChangeDescription(
+        String actualDescription = EditModuleRoleOperation.getModuleCodeChangesDescription(
                 moduleRoleMapBefore, moduleRoleMapAfter
         );
         String expectedDescription = "Module role(s) added: "


### PR DESCRIPTION
After this change, the `edit` command will fail **without changing data** when any of the module-role pair supplied by the user will cause an error. 

Assume the first person has the following roles:
`CS2103T-Tutor, MA1521-Student`

All the scenarios below will trigger the above behavior:

# Case 1 
Adding a module role pair to a person who already assumes a different role for this module
`edit 1 r/+CS2103T-Student`

# Case 2
Adding a module role pair to a person who already assumes the same role for this module
`edit 1 r/+CS2103T-Tutor`

# Case 3
Deleting a module role pair to a person who assumes a different role for this module
`edit 1 r/-CS2103T-Student`

# Case 4
Deleting a module role pair to a person who does not assume any role for this module
`edit 1 r/-CS2101-Student`

# Case 5
The user supplies multiple roles and some of them fall under the 4 cases mentioned above
`edit 1 r/-CS2103T-Tutor CS2101-Student`

closes #167 