### PR TITLE
Sort module role pairs in edit message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/edit/AddModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/AddModuleRoleOperation.java
@@ -16,6 +16,8 @@ public class AddModuleRoleOperation extends EditModuleRoleOperation {
 
     private final ModuleRoleMap moduleRoleMapToAdd;
     private final Logger logger = LogsCenter.getLogger(getClass());
+    private static final String MESSAGE_MODULE_ROLE_PAIRS_CLASH = "You wish to add these module role pair(s) "
+            + "but they clash with existing ones: %1$s";
 
     /**
      * Constructor for AddModuleRoleOperation.
@@ -33,15 +35,15 @@ public class AddModuleRoleOperation extends EditModuleRoleOperation {
     @Override
     protected ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit) throws CommandException {
         HashMap<ModuleCode, RoleType> roles = new HashMap<>(moduleRoleMapToEdit.getRoles());
-        ModuleRoleMap ret = new ModuleRoleMap(roles);
-        ModuleRoleMap failed = ret.putAll(moduleRoleMapToAdd);
+        ModuleRoleMap result = new ModuleRoleMap(roles);
+        ModuleRoleMap failed = result.putAll(moduleRoleMapToAdd);
         if (!failed.isEmpty()) {
-            throw new CommandException("You wish to add these module role pair(s) but they clash with existing ones: "
-                    + failed.getData());
+            throw new CommandException(String.format(MESSAGE_MODULE_ROLE_PAIRS_CLASH,
+                    failed.getData(true)));
         }
         logger.info("Added module roles: " + moduleRoleMapToAdd.getData()
                 + "to: " + moduleRoleMapToEdit.getData());
-        return ret;
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/edit/AddModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/AddModuleRoleOperation.java
@@ -14,10 +14,10 @@ import seedu.address.model.person.RoleType;
  */
 public class AddModuleRoleOperation extends EditModuleRoleOperation {
 
-    private final ModuleRoleMap moduleRoleMapToAdd;
-    private final Logger logger = LogsCenter.getLogger(getClass());
     private static final String MESSAGE_MODULE_ROLE_PAIRS_CLASH = "You wish to add these module role pair(s) "
             + "but they clash with existing ones: %1$s";
+    private final ModuleRoleMap moduleRoleMapToAdd;
+    private final Logger logger = LogsCenter.getLogger(getClass());
 
     /**
      * Constructor for AddModuleRoleOperation.

--- a/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
@@ -16,6 +16,8 @@ public class DeleteModuleRoleOperation extends EditModuleRoleOperation {
 
     private final Logger logger = LogsCenter.getLogger(getClass());
     private final ModuleRoleMap moduleRoleMapToDelete;
+    private static final String MESSAGE_MODULE_ROLE_PAIRS_DO_NOT_EXIST = "You wish to delete these module role pair(s) "
+            + "but they do not exist: %1$s";
 
     /**
      * Constructor for DeleteModuleRoleOperation.
@@ -33,15 +35,15 @@ public class DeleteModuleRoleOperation extends EditModuleRoleOperation {
     @Override
     protected ModuleRoleMap execute(ModuleRoleMap moduleRoleMapToEdit) throws CommandException {
         HashMap<ModuleCode, RoleType> roles = new HashMap<>(moduleRoleMapToEdit.getRoles());
-        ModuleRoleMap ret = new ModuleRoleMap(roles);
-        ModuleRoleMap failed = ret.removeAll(moduleRoleMapToDelete);
+        ModuleRoleMap result = new ModuleRoleMap(roles);
+        ModuleRoleMap failed = result.removeAll(moduleRoleMapToDelete);
         if (!failed.isEmpty()) {
-            throw new CommandException("You wish to delete these module role pair(s) but they do not exist: "
-                    + failed.getData(true));
+            throw new CommandException(String.format(MESSAGE_MODULE_ROLE_PAIRS_DO_NOT_EXIST,
+                    failed.getData(true)));
         }
         logger.info("Deleted module roles: " + moduleRoleMapToDelete.getData()
                 + "from: " + moduleRoleMapToEdit.getData(true));
-        return ret;
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
@@ -37,10 +37,10 @@ public class DeleteModuleRoleOperation extends EditModuleRoleOperation {
         ModuleRoleMap failed = ret.removeAll(moduleRoleMapToDelete);
         if (!failed.isEmpty()) {
             throw new CommandException("You wish to delete these module role pair(s) but they do not exist: "
-                    + failed.getData());
+                    + failed.getData(true));
         }
         logger.info("Deleted module roles: " + moduleRoleMapToDelete.getData()
-                + "from: " + moduleRoleMapToEdit.getData());
+                + "from: " + moduleRoleMapToEdit.getData(true));
         return ret;
     }
 

--- a/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/DeleteModuleRoleOperation.java
@@ -14,10 +14,10 @@ import seedu.address.model.person.RoleType;
  */
 public class DeleteModuleRoleOperation extends EditModuleRoleOperation {
 
-    private final Logger logger = LogsCenter.getLogger(getClass());
-    private final ModuleRoleMap moduleRoleMapToDelete;
     private static final String MESSAGE_MODULE_ROLE_PAIRS_DO_NOT_EXIST = "You wish to delete these module role pair(s) "
             + "but they do not exist: %1$s";
+    private final Logger logger = LogsCenter.getLogger(getClass());
+    private final ModuleRoleMap moduleRoleMapToDelete;
 
     /**
      * Constructor for DeleteModuleRoleOperation.

--- a/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
@@ -56,8 +56,7 @@ public abstract class EditModuleRoleOperation {
             ModuleRoleMap moduleRoleMapBefore, ModuleRoleMap moduleRoleMapAfter) {
 
         StringBuilder stringBuilderAdded = new StringBuilder();
-        moduleRoleMapAfter.getData().stream()
-                .sorted(Comparator.comparing(ModuleRolePair::toString))
+        moduleRoleMapAfter.getData(true)
                 .forEach(moduleRolePair -> {
                     if (!moduleRoleMapBefore.containsModuleRolePair(moduleRolePair)) {
                         stringBuilderAdded.append(moduleRolePair).append(" ");
@@ -65,8 +64,7 @@ public abstract class EditModuleRoleOperation {
                 });
 
         StringBuilder stringBuilderDeleted = new StringBuilder();
-        moduleRoleMapBefore.getData().stream()
-                .sorted(Comparator.comparing(ModuleRolePair::toString))
+        moduleRoleMapBefore.getData(true)
                 .forEach(moduleRolePair -> {
                     if (!moduleRoleMapAfter.containsModuleRolePair(moduleRolePair)) {
                         stringBuilderDeleted.append(moduleRolePair).append(" ");

--- a/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands.edit;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -55,27 +56,27 @@ public abstract class EditModuleRoleOperation {
             ModuleRoleMap moduleRoleMapBefore, ModuleRoleMap moduleRoleMapAfter) {
 
         StringBuilder stringBuilderAdded = new StringBuilder();
-        boolean hasAdded = false;
-        for (ModuleRolePair moduleRolePair : moduleRoleMapAfter.getData()) {
-            if (!moduleRoleMapBefore.containsModuleRolePair(moduleRolePair)) {
-                hasAdded = true;
-                stringBuilderAdded.append(moduleRolePair).append(" ");
-            }
-        }
+        moduleRoleMapAfter.getData().stream()
+                .sorted(Comparator.comparing(ModuleRolePair::toString))
+                .forEach(moduleRolePair -> {
+                    if (!moduleRoleMapBefore.containsModuleRolePair(moduleRolePair)) {
+                        stringBuilderAdded.append(moduleRolePair).append(" ");
+                    }
+                });
 
         StringBuilder stringBuilderDeleted = new StringBuilder();
-        boolean hasDeleted = false;
-        for (ModuleRolePair moduleRolePair : moduleRoleMapBefore.getData()) {
-            if (!moduleRoleMapAfter.containsModuleRolePair(moduleRolePair)) {
-                hasDeleted = true;
-                stringBuilderDeleted.append(moduleRolePair).append(" ");
-            }
-        }
+        moduleRoleMapBefore.getData().stream()
+                .sorted(Comparator.comparing(ModuleRolePair::toString))
+                .forEach(moduleRolePair -> {
+                    if (!moduleRoleMapAfter.containsModuleRolePair(moduleRolePair)) {
+                        stringBuilderDeleted.append(moduleRolePair).append(" ");
+                    }
+                });
         List<String> finalDescription = new ArrayList<>();
-        if (hasAdded) {
+        if (!stringBuilderAdded.toString().isEmpty()) {
             finalDescription.add("Module role(s) added: " + stringBuilderAdded.toString().strip());
         }
-        if (hasDeleted) {
+        if (!stringBuilderDeleted.toString().isEmpty()) {
             finalDescription.add("Module role(s) deleted: " + stringBuilderDeleted.toString().strip());
         }
 

--- a/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
@@ -21,6 +21,8 @@ public abstract class EditModuleRoleOperation {
             e.g. +CS1101S MA1521-TA
             adds CS1101S-Student and MA1521-Tutor to the person
             """;
+    private static final String MODULE_ROLE_ADDED = "Module role(s) added: ";
+    private static final String MODULE_ROLE_DELETED = "Module role(s) deleted: ";
 
     /**
      * Executes the operation on the given module role map.
@@ -70,10 +72,10 @@ public abstract class EditModuleRoleOperation {
                 });
         List<String> finalDescription = new ArrayList<>();
         if (!stringBuilderAdded.toString().isEmpty()) {
-            finalDescription.add("Module role(s) added: " + stringBuilderAdded.toString().strip());
+            finalDescription.add(MODULE_ROLE_ADDED + stringBuilderAdded.toString().strip());
         }
         if (!stringBuilderDeleted.toString().isEmpty()) {
-            finalDescription.add("Module role(s) deleted: " + stringBuilderDeleted.toString().strip());
+            finalDescription.add(MODULE_ROLE_DELETED + stringBuilderDeleted.toString().strip());
         }
 
         return String.join("\n", finalDescription);

--- a/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModuleRoleOperation.java
@@ -1,13 +1,11 @@
 package seedu.address.logic.commands.edit;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.ModuleRoleMap;
-import seedu.address.model.person.ModuleRolePair;
 
 /**
  * Represents an operation to edit a person's module roles.

--- a/src/main/java/seedu/address/model/person/ModuleCode.java
+++ b/src/main/java/seedu/address/model/person/ModuleCode.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a module code of a NUS module in the address book.
  * Guarantees: immutable
  */
-public class ModuleCode {
+public class ModuleCode implements Comparable<ModuleCode> {
     public static final String MESSAGE_CONSTRAINTS =
             "Module code should only contain alphanumeric characters, and it should not be blank.\n"
             + "The accepted pattern is [Alphabets][Numbers][Alphabets], where the ending [Alphabets] are optional.\n"
@@ -66,4 +66,8 @@ public class ModuleCode {
         return moduleCode.hashCode();
     }
 
+    @Override
+    public int compareTo(ModuleCode o) {
+        return this.moduleCode.compareTo(o.moduleCode);
+    }
 }

--- a/src/main/java/seedu/address/model/person/ModuleRoleMap.java
+++ b/src/main/java/seedu/address/model/person/ModuleRoleMap.java
@@ -173,9 +173,24 @@ public class ModuleRoleMap {
      * Returns a list of strings representing module role pairs for the GUI.
      */
     public List<ModuleRolePair> getData() {
-        return roles.entrySet().stream()
-                .map(entry -> new ModuleRolePair(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
+        return getData(false);
+    }
+
+    /**
+     * Returns a list of strings representing module role pairs for the GUI.
+     * @param sorted whether to sort the list based on the {@code ModuleRolePair}'s natural ordering.
+     */
+    public List<ModuleRolePair> getData(boolean sorted) {
+        if (sorted) {
+            return roles.entrySet().stream()
+                    .map(entry -> new ModuleRolePair(entry.getKey(), entry.getValue()))
+                    .sorted()
+                    .collect(Collectors.toList());
+        } else {
+            return roles.entrySet().stream()
+                    .map(entry -> new ModuleRolePair(entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList());
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/ModuleRolePair.java
+++ b/src/main/java/seedu/address/model/person/ModuleRolePair.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Represents a key-value pair for ModuleRoleMap.
  * Guarantees: immutable
  */
-public class ModuleRolePair {
+public class ModuleRolePair implements Comparable<ModuleRolePair> {
 
     public final ModuleCode moduleCode;
     public final RoleType roleType;
@@ -51,4 +51,15 @@ public class ModuleRolePair {
         return hash(moduleCode, roleType);
     }
 
+    /**
+     * Defines a natural ordering for {@code ModuleRolePair}.
+     * It is ordered by the lexicographical ordering of {@code ModuleCode} first,
+     * then by the declaration order of {@code RoleType}.
+     */
+    @Override
+    public int compareTo(ModuleRolePair o) {
+        return this.moduleCode.equals(o.moduleCode)
+            ? this.roleType.compareTo(o.roleType)
+            : this.moduleCode.compareTo(o.moduleCode);
+    }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -88,8 +88,7 @@ public class PersonCard extends UiPart<Region> {
 
         // Add module role pairs
         Integer roleLabelFontSize = 14;
-        person.getModuleRoleMap().getData().stream()
-                .sorted(Comparator.comparing(moduleRolePair -> moduleRolePair.moduleCode.toString()))
+        person.getModuleRoleMap().getData(true).stream()
                 .forEach(moduleRolePair -> {
                     Label curLabel = new Label(moduleRolePair.toString());
 


### PR DESCRIPTION
Now the error message as well as the command result message will have the module roles sorted.
![image](https://github.com/user-attachments/assets/86914ee4-5ee3-4c76-bcfa-6213665a0cf4)
![image](https://github.com/user-attachments/assets/e0fc2c30-a78e-4ba0-890a-b954cec8bd6e)

To facilitate the above change, I have implemented some additional internal logic:
- Make `ModuleCode` implement `Comparable<ModuleCode>` which delegates comparison to its wrapped module code string;
- Make `ModuleRolePair` implement `Comparable<ModuleRolePair>`, which compares the module code by the above ordering first. When equal, it compares the role type by the declaration order of each enum value.
- Overload `ModuleRoleMap.getData()` with a new `ModuleRoleMap.getData(sorted)` which optionally sorts the returned list of ModuleRolePairs by its natural ordering.

closes #173 