### PR TITLE
Tweak name validation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -98,6 +98,8 @@ Format: `help`
 Adds a person to the address book.
 
 Format: `add n/NAME (p/PHONE_NUMBER | e/EMAIL) (r/MODULECODE[-ROLETYPE])+ [a/ADDRESS] [t/TAG]+`
+
+* `NAME` refers to the name of a person. Refer to the [input format section](#input-format) to find out more.
 * `MODULECODE` refers to a module code of a NUS module (e.g. CS1101S, MA1521)
 * `ROLETYPE` refers to one of the following: `student`, `ta`, `tutor`, `prof`, `professor`.
 * The `r/MODULECODE[-ROLETYPE]` parameter means that the person has the role for this module (e.g. `r/CS1101S-student` means that the person is a student of CS1101S).
@@ -276,6 +278,19 @@ Furthermore, certain edits can cause the AddressBook to behave in unexpected way
 ### Archiving data files `[coming in v2.0]`
 
 _Details coming soon ..._
+
+--------------------------------------------------------------------------------------------------------------------
+
+## Input format
+
+### Name
+
+A name is a space-separated string of words.
+
+- Words can contain alphanumeric characters (letters and numbers).
+- Hyphens `-` are allowed within a word (not at the start or end) but cannot appear consecutively.
+- A comma `,` is allowed only at the end of a word.
+- Apart from the above criteria, `s/o` and `d/o` (or any capitalized form) are valid words, but they cannot be the first or last word of the name.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -30,6 +30,7 @@
 * [User Guide]({{ baseUrl }}/UserGuide.html) :expanded:
   * [Quick Start]({{ baseUrl }}/UserGuide.html#quick-start)
   * [Features]({{ baseUrl }}/UserGuide.html#features)
+  * [Input format]({{ baseUrl }}/UserGuide.html#input-format)
   * [FAQ]({{ baseUrl }}/UserGuide.html#faq)
   * [Command Summary]({{ baseUrl }}/UserGuide.html#faq)
 * [Developer Guide]({{ baseUrl }}/DeveloperGuide.html) :expanded:

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -13,7 +13,7 @@ public class Name {
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
-     * The first character of the address must not be a whitespace,
+     * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -23,12 +23,12 @@ public class Name {
      */
     public static final String VALIDATION_REGEX = ""
         + "^"
-        + NAME_FIRST_WORD_REGEX                // 1st word
-        + "(\\s+("                             // Additional words are separated by a space, then
-        + NAME_FIRST_WORD_REGEX + "|"          // (either: 1st word |
-        + "(?:[sSdD]/[oO]))"                   // or: Allow s/o, d/o, S/O, D/O as non-first words)
-        + ")*"                                 // Close group, allow 0 or more
-        + "$";                                 // End of the string
+        + NAME_FIRST_WORD_REGEX                                // 1st word
+        + "(\\s+("                                             // Additional words are separated by a space, then
+        + NAME_FIRST_WORD_REGEX + "|"                          // (either: 1st word |
+        + "(?:[sSdD]/[oO]\\s+" + NAME_FIRST_WORD_REGEX + "))"  // or: Allow s/o, d/o, S/O, D/O as non-first/non-last words)
+        + ")*"                                                 // Close group, allow 0 or more
+        + "$";                                                 // End of the string
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+        "Names can only contain letters, numbers, spaces, hyphens within words, and commas at the end of words. "
+      + "They should not start or end with a hyphen or comma, and names cannot be blank. "
+      + "Additionally, 's/o' or 'd/o' (or uppercase versions) are allowed in the middle of a name.";
+
 
     private static final String NAME_FIRST_WORD_REGEX = ""
         + "(\\p{Alnum}+"              // Starts with alphanumeric

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,9 +16,10 @@ public class Name {
         + "(\\p{Alnum}+"              // Starts with alphanumeric
         + "(?:-\\p{Alnum}+)*,?)";     // Allow mid-word hyphens or trailing comma
 
-    /*
-     * The first character of the name must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+    /**
+     * Matches a name string where the first word is alphanumeric with optional hyphens and trailing comma.
+     * Subsequent words are separated by spaces and can be either similar words or "s/o", "d/o", "S/O", "D/O".
+     * Entire string must follow this structure from start to end.
      */
     public static final String VALIDATION_REGEX = ""
         + "^"

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -11,8 +11,8 @@ public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
         "Names can only contain letters, numbers, spaces, hyphens within words, and commas at the end of words. "
-      + "They should not start or end with a hyphen or comma, and names cannot be blank. "
-      + "Additionally, 's/o' or 'd/o' (or uppercase versions) are allowed in the middle of a name.";
+        + "They should not start or end with a hyphen or comma, and names cannot be blank. "
+        + "Additionally, 's/o' or 'd/o' (or uppercase versions) are allowed in the middle of a name.";
 
 
     private static final String NAME_FIRST_WORD_REGEX = ""
@@ -29,7 +29,8 @@ public class Name {
         + NAME_FIRST_WORD_REGEX                                // 1st word
         + "(\\s+("                                             // Additional words are separated by a space, then
         + NAME_FIRST_WORD_REGEX + "|"                          // (either: 1st word |
-        + "(?:[sSdD]/[oO]\\s+" + NAME_FIRST_WORD_REGEX + "))"  // or: Allow s/o, d/o, S/O, D/O as non-first/non-last words)
+        + "(?:[sSdD]/[oO]\\s+" + NAME_FIRST_WORD_REGEX + "))"  // or: Allow s/o, d/o, S/O, D/O as
+                                                               // non-first/non-last words)
         + ")*"                                                 // Close group, allow 0 or more
         + "$";                                                 // End of the string
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,8 +16,8 @@ public class Name {
 
 
     private static final String NAME_FIRST_WORD_REGEX = ""
-        + "(\\p{Alnum}+"              // Starts with alphanumeric
-        + "(?:-\\p{Alnum}+)*,?)";     // Allow mid-word hyphens or trailing comma
+        + "(\\p{Alnum}+" // Starts with alphanumeric
+        + "(?:-\\p{Alnum}+)*,?)"; // Allow mid-word hyphens or trailing comma
 
     /**
      * Matches a name string where the first word is alphanumeric with optional hyphens and trailing comma.
@@ -25,14 +25,12 @@ public class Name {
      * Entire string must follow this structure from start to end.
      */
     public static final String VALIDATION_REGEX = ""
-        + "^"
-        + NAME_FIRST_WORD_REGEX                                // 1st word
-        + "(\\s+("                                             // Additional words are separated by a space, then
-        + NAME_FIRST_WORD_REGEX + "|"                          // (either: 1st word |
-        + "(?:[sSdD]/[oO]\\s+" + NAME_FIRST_WORD_REGEX + "))"  // or: Allow s/o, d/o, S/O, D/O as
-                                                               // non-first/non-last words)
-        + ")*"                                                 // Close group, allow 0 or more
-        + "$";                                                 // End of the string
+        + "^" + NAME_FIRST_WORD_REGEX // 1st word
+        + "(\\s+(" // Additional words are separated by a space, then
+        + NAME_FIRST_WORD_REGEX + "|" // (either: 1st word |
+        + "(?:[sSdD]/[oO]\\s+" + NAME_FIRST_WORD_REGEX + "))" // or: Allow s/o as non-first/non-last word)
+        + ")*" // Close group, allow 0 or more
+        + "$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -12,11 +12,22 @@ public class Name {
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
+    private static final String NAME_FIRST_WORD_REGEX = ""
+        + "(\\p{Alnum}+"              // Starts with alphanumeric
+        + "(?:-\\p{Alnum}+)*,?)";     // Allow mid-word hyphens or trailing comma
+
     /*
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = ""
+        + "^"
+        + NAME_FIRST_WORD_REGEX                // 1st word
+        + "(\\s+("                             // Additional words are separated by a space, then
+        + NAME_FIRST_WORD_REGEX + "|"          // EITHER 1st word
+        + "(?:[sSdD]/[oO])"                    // OR: Allow s/o, d/o, S/O, D/O as non-first words
+        + "))*"                                // Close EITHER/OR, close group, allow 0 or more
+        + "$";                                 // End of the string
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -24,9 +24,9 @@ public class Name {
         + "^"
         + NAME_FIRST_WORD_REGEX                // 1st word
         + "(\\s+("                             // Additional words are separated by a space, then
-        + NAME_FIRST_WORD_REGEX + "|"          // EITHER 1st word
-        + "(?:[sSdD]/[oO])"                    // OR: Allow s/o, d/o, S/O, D/O as non-first words
-        + "))*"                                // Close EITHER/OR, close group, allow 0 or more
+        + NAME_FIRST_WORD_REGEX + "|"          // (either: 1st word |
+        + "(?:[sSdD]/[oO]))"                   // or: Allow s/o, d/o, S/O, D/O as non-first words)
+        + ")*"                                 // Close group, allow 0 or more
         + "$";                                 // End of the string
 
     public final String fullName;

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -31,42 +31,42 @@ public class NameTest {
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
 
         // '-' should be mid-word
-        assertFalse(Name.isValidName("-peter"));          // start of first word
-        assertFalse(Name.isValidName("peter-"));          // end of first word
-        assertFalse(Name.isValidName("peter -tan"));      // start of nonfirst word
-        assertFalse(Name.isValidName("peter tan-"));      // end of nonfirst word
-        assertFalse(Name.isValidName("peter tan--lee"));  // consecutive dashes
+        assertFalse(Name.isValidName("-peter")); // start of first word
+        assertFalse(Name.isValidName("peter-")); // end of first word
+        assertFalse(Name.isValidName("peter -tan")); // start of nonfirst word
+        assertFalse(Name.isValidName("peter tan-")); // end of nonfirst word
+        assertFalse(Name.isValidName("peter tan--lee")); // consecutive dashes
         assertFalse(Name.isValidName("-"));
 
         // ',' should be end-word, and not the first character
-        assertFalse(Name.isValidName(",peter"));       // start of first word
-        assertFalse(Name.isValidName("p,eter"));       // mid of first word
-        assertFalse(Name.isValidName("peter ,tan"));   // start of nonfirst word
-        assertFalse(Name.isValidName("peter t,an"));   // mid of nonfirst word
-        assertFalse(Name.isValidName("peter,, tan"));  // consecutive commas
+        assertFalse(Name.isValidName(",peter")); // start of first word
+        assertFalse(Name.isValidName("p,eter")); // mid of first word
+        assertFalse(Name.isValidName("peter ,tan")); // start of nonfirst word
+        assertFalse(Name.isValidName("peter t,an")); // mid of nonfirst word
+        assertFalse(Name.isValidName("peter,, tan")); // consecutive commas
         assertFalse(Name.isValidName(","));
 
         // '/' should only appear in the context of [sSdD]/[oO]
-        assertFalse(Name.isValidName("peter a/o david"));  // mismatch of [sSdD]
-        assertFalse(Name.isValidName("peter s/a david"));  // mismatch of [oO]
-        assertFalse(Name.isValidName("/peter"));           // start of first word
-        assertFalse(Name.isValidName("peter/"));           // end of first word
-        assertFalse(Name.isValidName("peter /tan"));       // start of nonfirst word
-        assertFalse(Name.isValidName("peter tan/"));       // end of nonfirst word
-        assertFalse(Name.isValidName("peter s//o tan"));   // consecutive slashes
+        assertFalse(Name.isValidName("peter a/o david")); // mismatch of [sSdD]
+        assertFalse(Name.isValidName("peter s/a david")); // mismatch of [oO]
+        assertFalse(Name.isValidName("/peter")); // start of first word
+        assertFalse(Name.isValidName("peter/")); // end of first word
+        assertFalse(Name.isValidName("peter /tan")); // start of nonfirst word
+        assertFalse(Name.isValidName("peter tan/")); // end of nonfirst word
+        assertFalse(Name.isValidName("peter s//o tan")); // consecutive slashes
         assertFalse(Name.isValidName("/"));
 
         // [sSdD]/[oO] should be its own word
-        assertFalse(Name.isValidName("peter as/o david"));   // extra chars before
-        assertFalse(Name.isValidName("peter s/oa david"));   // extra chars after
-        assertFalse(Name.isValidName("peter as/oa david"));  // extra chars before after
+        assertFalse(Name.isValidName("peter as/o david")); // extra chars before
+        assertFalse(Name.isValidName("peter s/oa david")); // extra chars after
+        assertFalse(Name.isValidName("peter as/oa david")); // extra chars before after
 
         // [sSdD]/[oO] should not be first or last word
-        assertFalse(Name.isValidName("s/o peter david"));    // should not be the first word
-        assertFalse(Name.isValidName("peter david s/o"));    // should not be the last word
+        assertFalse(Name.isValidName("s/o peter david")); // should not be the first word
+        assertFalse(Name.isValidName("peter david s/o")); // should not be the last word
 
         // combination
-        assertFalse(Name.isValidName("peter tan-,"));  // comma should be preceded by alphanumeric
+        assertFalse(Name.isValidName("peter tan-,")); // comma should be preceded by alphanumeric
     }
 
     @Test
@@ -80,11 +80,11 @@ public class NameTest {
 
         // '-' should be mid-word
         assertTrue(Name.isValidName("peter tan-lee"));
-        assertTrue(Name.isValidName("peter tan-l-ee"));  // multiple dashes in a word
+        assertTrue(Name.isValidName("peter tan-l-ee")); // multiple dashes in a word
 
         // ',' should be end-word, and not the first character
         assertTrue(Name.isValidName("tan ah kow, peter"));
-        assertTrue(Name.isValidName("tan, ah, kow, peter"));  // multiple commas
+        assertTrue(Name.isValidName("tan, ah, kow, peter")); // multiple commas
 
         // '/' should only appear in the context of [sSdD]/[oO]
         assertTrue(Name.isValidName("peter s/o david"));

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -20,7 +20,7 @@ public class NameTest {
     }
 
     @Test
-    public void isValidName() {
+    public void isInvalidName() {
         // null name
         assertThrows(NullPointerException.class, () -> Name.isValidName(null));
 
@@ -29,7 +29,10 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+    }
 
+    @Test
+    public void isValidName() {
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
         assertTrue(Name.isValidName("12345")); // numbers only

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,6 +29,44 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+
+        // '-' should be mid-word
+        assertFalse(Name.isValidName("-peter"));          // start of first word
+        assertFalse(Name.isValidName("peter-"));          // end of first word
+        assertFalse(Name.isValidName("peter -tan"));      // start of nonfirst word
+        assertFalse(Name.isValidName("peter tan-"));      // end of nonfirst word
+        assertFalse(Name.isValidName("peter tan--lee"));  // consecutive dashes
+        assertFalse(Name.isValidName("-"));
+
+        // ',' should be end-word, and not the first character
+        assertFalse(Name.isValidName(",peter"));       // start of first word
+        assertFalse(Name.isValidName("p,eter"));       // mid of first word
+        assertFalse(Name.isValidName("peter ,tan"));   // start of nonfirst word
+        assertFalse(Name.isValidName("peter t,an"));   // mid of nonfirst word
+        assertFalse(Name.isValidName("peter,, tan"));  // consecutive commas
+        assertFalse(Name.isValidName(","));
+
+        // '/' should only appear in the context of [sSdD]/[oO]
+        assertFalse(Name.isValidName("peter a/o david"));  // mismatch of [sSdD]
+        assertFalse(Name.isValidName("peter s/a david"));  // mismatch of [oO]
+        assertFalse(Name.isValidName("/peter"));           // start of first word
+        assertFalse(Name.isValidName("peter/"));           // end of first word
+        assertFalse(Name.isValidName("peter /tan"));       // start of nonfirst word
+        assertFalse(Name.isValidName("peter tan/"));       // end of nonfirst word
+        assertFalse(Name.isValidName("peter s//o tan"));   // consecutive slashes
+        assertFalse(Name.isValidName("/"));
+
+        // [sSdD]/[oO] should be its own word
+        assertFalse(Name.isValidName("peter as/o david"));   // extra chars before
+        assertFalse(Name.isValidName("peter s/oa david"));   // extra chars after
+        assertFalse(Name.isValidName("peter as/oa david"));  // extra chars before after
+
+        // [sSdD]/[oO] should not be first or last word
+        assertFalse(Name.isValidName("s/o peter david"));    // should not be the first word
+        assertFalse(Name.isValidName("peter david s/o"));    // should not be the last word
+
+        // combination
+        assertFalse(Name.isValidName("peter tan-,"));  // comma should be preceded by alphanumeric
     }
 
     @Test
@@ -39,6 +77,20 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+
+        // '-' should be mid-word
+        assertTrue(Name.isValidName("peter tan-lee"));
+        assertTrue(Name.isValidName("peter tan-l-ee"));  // multiple dashes in a word
+
+        // ',' should be end-word, and not the first character
+        assertTrue(Name.isValidName("tan ah kow, peter"));
+        assertTrue(Name.isValidName("tan, ah, kow, peter"));  // multiple commas
+
+        // '/' should only appear in the context of [sSdD]/[oO]
+        assertTrue(Name.isValidName("peter s/o david"));
+        assertTrue(Name.isValidName("peter S/o david"));
+        assertTrue(Name.isValidName("peter s/O david"));
+        assertTrue(Name.isValidName("emily d/o david"));
     }
 
     @Test


### PR DESCRIPTION
Closes #125, a step towards #156

- `Name` is now interpreted as a string of space separated words.
- A word either
    - contains alphanumeric chars, mid-word `-`, end-word `,`,
    - or the word is `s/o` or `d/o` (capitalized versions allowed)