### PR TITLE
Bugfix: `Optional[]` no longer displayed in edit messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
@@ -145,13 +145,15 @@ public class EditCommand extends Command {
         }
         if (!personBefore.getPhone().equals(personAfter.getPhone())) {
             isChanged = true;
-            changesDescription.append("Phone: ").append(personBefore.getPhone()).append(" -> ")
-                    .append(personAfter.getPhone()).append("\n");
+            changesDescription.append("Phone: ")
+                    .append(personBefore.getPhone().map(Object::toString).orElse("<no phone>")).append(" -> ")
+                    .append(personAfter.getPhone().map(Object::toString).orElse("<no phone>")).append("\n");
         }
         if (!personBefore.getEmail().equals(personAfter.getEmail())) {
             isChanged = true;
-            changesDescription.append("Email: ").append(personBefore.getEmail()).append(" -> ")
-                    .append(personAfter.getEmail()).append("\n");
+            changesDescription.append("Email: ")
+                    .append(personBefore.getEmail().map(Object::toString).orElse("<no email>")).append(" -> ")
+                    .append(personAfter.getEmail().map(Object::toString).orElse("<no email>")).append("\n");
         }
         if (!personBefore.getAddress().equals(personAfter.getAddress())) {
             isChanged = true;

--- a/src/test/java/seedu/address/logic/commands/edit/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/edit/EditCommandTest.java
@@ -237,10 +237,12 @@ public class EditCommandTest {
 
         String expected = "Change(s) made: "
                 + "\nName: " + person.getName() + " -> " + editedPerson.getName()
-                + "\nPhone: " + person.getPhone() + " -> " + editedPerson.getPhone()
-                + "\nEmail: " + person.getEmail() + " -> " + editedPerson.getEmail()
-                + "\nAddress: " + person.getAddress().map(Object::toString).orElse("<no address>")
-                + " -> " + editedPerson.getAddress().map(Object::toString).orElse("<no address>")
+                + "\nPhone: " + person.getPhone().map(Object::toString).orElse("<no phone>") + " -> "
+                + editedPerson.getPhone().map(Object::toString).orElse("<no phone>")
+                + "\nEmail: " + person.getEmail().map(Object::toString).orElse("<no email>") + " -> "
+                + editedPerson.getEmail().map(Object::toString).orElse("<no email>")
+                + "\nAddress: " + person.getAddress().map(Object::toString).orElse("<no address>") + " -> "
+                + editedPerson.getAddress().map(Object::toString).orElse("<no address>")
                 + "\nTags: " + person.getTags() + " -> " + editedPerson.getTags()
                 + "\n" + EditModuleRoleOperation.getModuleCodeChangesDescription(
                         person.getModuleRoleMap(),


### PR DESCRIPTION
closes #153 

The cause is that `.toString()` was called directly on a `Optional` without calling `.orElse()` first.