### PR TITLE
Add search by tag

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -38,7 +38,7 @@ public class Messages {
      * Returns an error message indicating the duplicate prefixes.
      */
     public static String getErrorMessageForDuplicatePrefixes(Prefix... duplicatePrefixes) {
-        assert duplicatePrefixes.length > 0;
+        assert duplicatePrefixes.length > 0 : "No duplicate prefix found when prompting error message to user";
 
         Set<String> duplicateFields =
                 Stream.of(duplicatePrefixes).map(Prefix :: toString).collect(Collectors.toSet());
@@ -47,7 +47,7 @@ public class Messages {
     }
 
     public static String getErrorMessageForUnexpectedPrefixes(Prefix... unexpectedPrefixes) {
-        assert unexpectedPrefixes.length > 0;
+        assert unexpectedPrefixes.length > 0 : "No unexpected prefix found when prompting error message to user";
 
         Set<String> unexpectedFields =
                 Stream.of(unexpectedPrefixes).map(Prefix :: toString).collect(Collectors.toSet());

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -66,7 +66,8 @@ public class FindCommand extends Command {
      */
     public FindCommand(List<Predicate<Person>> predicates, boolean isChained) {
         // For now we only support 1, 2 or 3 predicates
-        assert predicates.size() <= 3 : "More than 3 predicates found for find command";
+        assert predicates.size() >= 1 && predicates.size() <= 3
+            : "More than 3 predicates found for find command";
         this.predicates = predicates;
         this.isChained = isChained;
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -66,7 +66,7 @@ public class FindCommand extends Command {
      */
     public FindCommand(List<Predicate<Person>> predicates, boolean isChained) {
         // For now we only support 1, 2 or 3 predicates
-        assert predicates.size() <= 3;
+        assert predicates.size() <= 3 : "More than 3 predicates found for find command";
         this.predicates = predicates;
         this.isChained = isChained;
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.InFilteredListPredicate;
 import seedu.address.model.person.ModuleRoleContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 
 /**
@@ -64,8 +65,8 @@ public class FindCommand extends Command {
      *                  If false, this command will search on the full list of persons.
      */
     public FindCommand(List<Predicate<Person>> predicates, boolean isChained) {
-        // For now we only support 1 or 2 predicates
-        assert predicates.size() == 1 || predicates.size() == 2;
+        // For now we only support 1, 2 or 3 predicates
+        assert predicates.size() <= 3;
         this.predicates = predicates;
         this.isChained = isChained;
     }
@@ -159,9 +160,11 @@ public class FindCommand extends Command {
      */
     private List<String> extractKeywords(Predicate<Person> predicate) {
         if (predicate instanceof NameContainsKeywordsPredicate) {
-            return ((NameContainsKeywordsPredicate) predicate).getKeywords();
+            return ((NameContainsKeywordsPredicate) predicate).getNameKeywords();
         } else if (predicate instanceof ModuleRoleContainsKeywordsPredicate) {
             return ((ModuleRoleContainsKeywordsPredicate) predicate).getModuleRolePairs();
+        } else if (predicate instanceof TagContainsKeywordsPredicate) {
+            return ((TagContainsKeywordsPredicate) predicate).getTagKeywords();
         }
         return Collections.emptyList();
     }

--- a/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
@@ -110,7 +110,7 @@ public class EditCommand extends Command {
      */
     private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor)
             throws CommandException {
-        assert personToEdit != null;
+        assert personToEdit != null : "PersonToEdit should not be null";
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Phone updatedPhone = editPersonDescriptor.getPhone().or(personToEdit :: getPhone).orElse(null);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -94,7 +94,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      * {@code Set<Tag>} containing zero tags.
      */
     private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
-        assert tags != null;
+        assert tags != null : "Tag collection should not be null";
 
         if (tags.isEmpty()) {
             return Optional.empty();
@@ -112,7 +112,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     private Optional<EditModuleRoleOperation> parseModuleRolesForEdit(String moduleRoleOperations)
             throws ParseException {
-        assert moduleRoleOperations != null;
+        assert moduleRoleOperations != null : "ModuleRoleOperation should not be null";
 
         if (moduleRoleOperations.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -23,6 +23,7 @@ import seedu.address.model.person.ModuleRoleContainsKeywordsPredicate;
 import seedu.address.model.person.ModuleRoleMap;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -47,7 +48,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         Prefix[] unexpectedPrefixes =
-                Stream.of(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_DESCRIPTION)
+                Stream.of(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_DESCRIPTION)
                         .filter(prefix -> argMultimap.getValue(prefix).isPresent())
                         .toArray(Prefix[]::new);
 
@@ -57,18 +58,22 @@ public class FindCommandParser implements Parser<FindCommand> {
                     FindCommand.MESSAGE_USAGE));
         }
 
-        // for this command, NAME_PREFIX or MODULE_PREFIX is mandatory; preamble is not allowed (except for "chained")
-        if (!areAnyPrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_MODULE)) {
+        // for this command, NAME_PREFIX TAG_PREFIX or MODULE_PREFIX is mandatory;
+        // preamble is not allowed (except for "chained")
+        if (!areAnyPrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TAG, PREFIX_MODULE)) {
             throw new ParseException(Messages.getErrorMessageWithUsage(MESSAGE_MISSING_SEARCH_KEYWORD,
                     FindCommand.MESSAGE_USAGE));
         }
 
         List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+        List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
         List<String> moduleRoleKeywords = argMultimap.getAllValues(PREFIX_MODULE);
         boolean isChained = argMultimap.getPreamble().equals(FindCommand.CHAINED);
 
         // all keywords must be non-empty and contain no whitespace
-        if (nameKeywords.stream().anyMatch(String::isBlank) || moduleRoleKeywords.stream().anyMatch(String::isBlank)) {
+        if (nameKeywords.stream().anyMatch(String::isBlank)
+            || tagKeywords.stream().anyMatch(String::isBlank)
+            || moduleRoleKeywords.stream().anyMatch(String::isBlank)) {
             throw new ParseException(Messages.getErrorMessageWithUsage(MESSAGE_EMPTY_FIND_KEYWORD,
                     FindCommand.MESSAGE_USAGE));
         }
@@ -79,9 +84,11 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (!nameKeywords.isEmpty()) {
             predicates.add(new NameContainsKeywordsPredicate(nameKeywords));
         }
+        if (!tagKeywords.isEmpty()) {
+            predicates.add(new TagContainsKeywordsPredicate(tagKeywords));
+        }
         if (!moduleRoleKeywords.isEmpty()) {
             predicates.add(new ModuleRoleContainsKeywordsPredicate(moduleRoleMapKeywords));
-
         }
 
         return new FindCommand(predicates, isChained);

--- a/src/main/java/seedu/address/model/person/ModuleRoleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ModuleRoleContainsKeywordsPredicate.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code ModuleRoleMap} matches any of the keywords given.
  */
 public class ModuleRoleContainsKeywordsPredicate implements Predicate<Person> {
     private final ModuleRoleMap moduleRoleMapKeywords;

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -38,7 +38,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
     }
 
-    public List<String> getKeywords() {
+    public List<String> getNameKeywords() {
         return Collections.unmodifiableList(keywords);
     }
 

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -37,7 +37,7 @@ public class Phone {
      */
     public static boolean isValidPhone(String test) {
         // Assert that there should not be whitespaces in the string
-        assert test.chars().noneMatch(ch -> ch == ' ');
+        assert test.chars().noneMatch(ch -> ch == ' ') : "Phone number itself should not contain space";
 
         long digitCount = test.chars()
             .filter(Character::isDigit)

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -1,0 +1,54 @@
+package seedu.address.model.person;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code Person}'s {@code Tags} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        Set<Tag> tags = person.getTags();
+        return tags.stream().anyMatch(tag ->
+            keywords.stream().anyMatch(keyword ->
+                StringUtil.containsSubstringIgnoreCase(tag.tagName, keyword))
+        );
+    }
+
+    public List<String> getTagKeywords() {
+        return Collections.unmodifiableList(keywords);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof TagContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        TagContainsKeywordsPredicate otherPredicate =
+            (TagContainsKeywordsPredicate) other;
+        return this.keywords.equals(otherPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -174,8 +174,8 @@ public class FindCommandTest {
     @Test
     public void execute_nonExistentTag_noPersonFound() throws ParseException {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0,
-            "(invalid)");
-        TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("invalid");
+            "(nothing)");
+        TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("nothing");
         List<Predicate<Person>> predicates = Arrays.asList(tagPredicate);
 
         FindCommand command = new FindCommand(predicates);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
@@ -31,6 +32,7 @@ import seedu.address.model.person.InFilteredListPredicate;
 import seedu.address.model.person.ModuleRoleContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -155,6 +157,34 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_nameAndModuleRoleAndTags_onePersonFound() throws ParseException {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1,
+            "(Benson) AND (CS1101S-Tutor) AND (friends)");
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Benson");
+        ModuleRoleContainsKeywordsPredicate moduleRolePredicate = prepareModuleRolePredicate("CS1101S-TA");
+        TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friends");
+        List<Predicate<Person>> predicates = Arrays.asList(namePredicate, moduleRolePredicate, tagPredicate);
+
+        FindCommand command = new FindCommand(predicates);
+        expectedModel.updateFilteredPersonList(namePredicate.and(moduleRolePredicate).and(tagPredicate));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_nonExistentTag_noPersonFound() throws ParseException {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0,
+            "(invalid)");
+        TagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("invalid");
+        List<Predicate<Person>> predicates = Arrays.asList(tagPredicate);
+
+        FindCommand command = new FindCommand(predicates);
+        expectedModel.updateFilteredPersonList(tagPredicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(), model.getFilteredPersonList());
+    }
+
+    @Test
     public void executeTwice_nameAndModuleRoleKeywordsChained_multiplePersonsFound() throws ParseException {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2,
                 Messages.MESSAGE_CHAINED_FIND_PREFIX + "(Kurz OR Elle) AND (CS1101S-Student)");
@@ -204,5 +234,13 @@ public class FindCommandTest {
     private ModuleRoleContainsKeywordsPredicate prepareModuleRolePredicate(String userInput) throws ParseException {
         return new ModuleRoleContainsKeywordsPredicate(ParserUtil.parseModuleRolePairs(
                 Arrays.asList(userInput.split("\\s+"))));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private TagContainsKeywordsPredicate prepareTagPredicate(String userInput) throws ParseException {
+        return new TagContainsKeywordsPredicate((
+            Arrays.asList(userInput.split("\\s+"))));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -163,10 +163,10 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validTag_returnsFindCommand() {
-        FindCommand expectedFindCommad =
+        FindCommand expectedFindCommand =
             new FindCommand(List.of(new TagContainsKeywordsPredicate(List.of("school"))),
                 true);
-        assertParseSuccess(parser, " " + PREFIX_TAG + "school", expectedFindCommad);
+        assertParseSuccess(parser, " " + PREFIX_TAG + "school", expectedFindCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -171,11 +171,11 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validTags_returnsFindCommand() {
-        FindCommand expectedFindCommad =
+        FindCommand expectedFindCommand =
             new FindCommand(List.of(new TagContainsKeywordsPredicate(List.of("school", "office", "finance"))),
                 true);
         assertParseSuccess(parser, " " + PREFIX_TAG + "school "
-            + PREFIX_TAG + "office " + PREFIX_TAG + "finance", expectedFindCommad);
+            + PREFIX_TAG + "office " + PREFIX_TAG + "finance", expectedFindCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIND_KEYWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -17,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.ModuleRoleContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -61,25 +63,31 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_invalidArg_throwsParseException() {
-        // 1
+        // Missing search keywords
         assertParseFailure(parser, "     ",
                 Messages.getErrorMessageWithUsage(FindCommandParser.MESSAGE_MISSING_SEARCH_KEYWORD,
                         FindCommand.MESSAGE_USAGE));
-        // 2
+        // Unexpected preamble(name)
         assertParseFailure(parser, "Alice " + PREFIX_MODULE + "CS2103T",
                 Messages.getErrorMessageWithUsage(Messages.MESSAGE_UNEXPECTED_PREAMBLE, FindCommand.MESSAGE_USAGE));
-        // 3
+        // Unexpected preamble(module)
         assertParseFailure(parser, "CS2103T " + PREFIX_NAME + "Alice",
                 Messages.getErrorMessageWithUsage(Messages.MESSAGE_UNEXPECTED_PREAMBLE, FindCommand.MESSAGE_USAGE));
-        // 4
+        // Unexpected preamble(tag)
+        assertParseFailure(parser, "CS2103T " + PREFIX_TAG + "Alice",
+            Messages.getErrorMessageWithUsage(Messages.MESSAGE_UNEXPECTED_PREAMBLE, FindCommand.MESSAGE_USAGE));
+        // Unexpected preamble(random input)
         assertParseFailure(parser, "random string " + PREFIX_NAME + "Alice",
                 Messages.getErrorMessageWithUsage(Messages.MESSAGE_UNEXPECTED_PREAMBLE, FindCommand.MESSAGE_USAGE));
-        // 5
+        // Blank keywords for name
         assertParseFailure(parser, " " + PREFIX_NAME + " ",
                 Messages.getErrorMessageWithUsage(MESSAGE_EMPTY_FIND_KEYWORD, FindCommand.MESSAGE_USAGE));
-        // 6
+        // Blank keywords for module
         assertParseFailure(parser, " " + PREFIX_MODULE + " ",
                 Messages.getErrorMessageWithUsage(MESSAGE_EMPTY_FIND_KEYWORD, FindCommand.MESSAGE_USAGE));
+        // Blank keywords for tag
+        assertParseFailure(parser, " " + PREFIX_TAG + " ",
+            Messages.getErrorMessageWithUsage(MESSAGE_EMPTY_FIND_KEYWORD, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -134,7 +142,8 @@ public class FindCommandParserTest {
                 + "CS2101 " + PREFIX_MODULE + "CS2103T-TA", expectedFindCommand);
     }
 
-    @Test void parse_chained_returnsFindCommand() throws ParseException {
+    @Test
+    public void parse_chained_returnsFindCommand() throws ParseException {
         // Test with chained keyword
         FindCommand expectedFindCommand =
                 new FindCommand(List.of(
@@ -152,5 +161,60 @@ public class FindCommandParserTest {
                 expectedFindCommand);
     }
 
+    @Test
+    public void parse_validTag_returnsFindCommand() {
+        FindCommand expectedFindCommad =
+            new FindCommand(List.of(new TagContainsKeywordsPredicate(List.of("school"))),
+                true);
+        assertParseSuccess(parser, " " + PREFIX_TAG + "school", expectedFindCommad);
+    }
+
+    @Test
+    public void parse_validTags_returnsFindCommand() {
+        FindCommand expectedFindCommad =
+            new FindCommand(List.of(new TagContainsKeywordsPredicate(List.of("school", "office", "finance"))),
+                true);
+        assertParseSuccess(parser, " " + PREFIX_TAG + "school "
+            + PREFIX_TAG + "office " + PREFIX_TAG + "finance", expectedFindCommad);
+    }
+
+    @Test
+    public void parse_validNameAndTags_returnsFindCommand() {
+        FindCommand expectedFindCommand =
+            new FindCommand(List.of(
+                new NameContainsKeywordsPredicate(List.of("Alice")),
+                new TagContainsKeywordsPredicate(List.of("school", "office", "finance"))),
+                false);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice " + PREFIX_TAG + "school "
+            + PREFIX_TAG + "office " + PREFIX_TAG + "finance", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validModuleRoleArgsAndTags_returnsFindCommand() throws ParseException {
+        FindCommand expectedFindCommand =
+            new FindCommand(List.of(
+                new TagContainsKeywordsPredicate(List.of("school", "office", "finance")),
+                new ModuleRoleContainsKeywordsPredicate(ParserUtil.parseModuleRolePairs(
+                    List.of("CS2103T")))
+            ));
+        assertParseSuccess(parser, " " + PREFIX_MODULE + "CS2103T "
+            + PREFIX_TAG + "school " + PREFIX_TAG + "office " + PREFIX_TAG + "finance",
+            expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() throws ParseException {
+        FindCommand expectedFindCommand =
+            new FindCommand(List.of(
+                new NameContainsKeywordsPredicate(List.of("Alice")),
+                new TagContainsKeywordsPredicate(List.of("school", "office", "finance")),
+                new ModuleRoleContainsKeywordsPredicate(ParserUtil.parseModuleRolePairs(
+                    List.of("CS2103T")))
+            ));
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice "
+                + PREFIX_MODULE + "CS2103T "
+                + PREFIX_TAG + "school " + PREFIX_TAG + "office " + PREFIX_TAG + "finance",
+            expectedFindCommand);
+    }
 }
 


### PR DESCRIPTION
Closes #219 

User can find contacts by tag, using command `find [t/tag]`
1. More than 1 tag search supported, syntax is `find t/tag1 t/tag2 t/tag3...`
2. Tag search is based on substring, hence if a contact contains a tag which has keyword as part of its substring, then this contact would appear in the search result

A side note is that, this is the PR where I found out that our address book frequently triggers assertion error and the fact that most of our assertions does not come with error message, I have done a quick fill up of the error messages in this PR, so after merging this, at least it is easier to trace assertionError