### PR TITLE
Fix phone validation

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -74,7 +74,7 @@ public class ParserUtil {
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
-        if (!Phone.isValidPhone(trimmedPhone)) {
+        if (!Phone.isValidPhoneField(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }
         return new Phone(trimmedPhone);

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -35,7 +35,7 @@ public class Phone {
      * Our definition of a valid phone number is a string without spaces that has
      * at least 3 digits, and no alphabets.
      */
-    public static boolean isValidPhone(String test) {
+    static boolean isValidPhone(String test) {
         // Assert that there should not be whitespaces in the string
         assert test.chars().noneMatch(ch -> ch == ' ');
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -89,7 +89,7 @@ class JsonAdaptedPerson {
         }
         final Name modelName = new Name(name);
 
-        if (phone != null && !Phone.isValidPhone(phone)) {
+        if (phone != null && !Phone.isValidPhoneField(phone)) {
             throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
         }
         final Phone modelPhone = phone != null ? new Phone(phone) : null;


### PR DESCRIPTION
Closes #221

The issue was that, for phone validation we should call the `isValidPhoneField` function instead of the `isValidPhone` function. By calling `isValidPhone` function directly with the `phone` field, we may pass in a string with spaces directly, causing the assertion to trigger.