### PR TITLE
Fix the issue of tags and matching being together in help message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -32,7 +32,7 @@ public class FindCommand extends Command {
     public static final String CHAINED = "chained";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds persons by their names, module-role pairs or tags"
+            + ": Finds persons by their names, module-role pairs or tags "
             + "matching any (combination) of the specified keywords (case-insensitive)"
             + "and displays them as a numbered list.\n"
             + "To search from the previously displayed results, use 'find " + CHAINED + "'. \n"


### PR DESCRIPTION
Closes #305

Change `tagsmatching` to `tags matching`. This should be considered as a grammatical error because `tagsmatching` is not a word and hence should be a bug and this PR should be a valid bug fix that does not violate feature freeze