### PR TITLE
Fix grammatical error in name validation error

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only should not be blank, and contain at least 1 character";
+            "Names should not be blank, and should contain at least 1 character";
 
     public final String fullName;
 


### PR DESCRIPTION
Closes #256.

This is allowed in v1.6 as stated in Week 11 Project tab:

![image](https://github.com/user-attachments/assets/18106e76-c1c0-43f5-a7d3-996e3213622c)
